### PR TITLE
chore(build): remove compromise and split manual chunks further

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@supabase/supabase-js": "^2.49.4",
     "@vercel/analytics": "^1.5.0",
     "browser-image-compression": "^2.0.2",
-    "compromise": "^14.14.4",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.9.7",
     "immer": "^10.1.1",

--- a/src/helpers/handle-async-action.ts
+++ b/src/helpers/handle-async-action.ts
@@ -1,5 +1,4 @@
 import { addToast } from '@heroui/react';
-import nlp from 'compromise';
 
 import { capitalize, getErrorMessage } from '@utils';
 
@@ -28,7 +27,7 @@ const parseActionType = (
 const getMessages = (actionType: ActionType) => {
   const { noun, verb } = parseActionType(actionType);
 
-  const pastTense = nlp(verb).verbs().toPastTense().text();
+  const pastTense = verb.endsWith('e') ? `${verb}d` : `${verb}ed`;
 
   return {
     error: `Something went wrong while ${verb}ing your ${noun}`,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,11 +24,15 @@ export default defineConfig(({ mode }) => {
               return 'supabase';
             }
 
+            if (id.includes('@phosphor-icons')) {
+              return 'phosphor-icons';
+            }
+
             if (id.includes('heroui')) {
               return 'heroui';
             }
 
-            if (id.includes('framer-motion')) {
+            if (id.includes('motion')) {
               return 'framer-motion';
             }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5687,17 +5687,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compromise@npm:^14.14.4":
-  version: 14.14.4
-  resolution: "compromise@npm:14.14.4"
-  dependencies:
-    efrt: "npm:2.7.0"
-    grad-school: "npm:0.0.5"
-    suffix-thumb: "npm:5.0.2"
-  checksum: 10c0/5af8080eb3f2b4f1deb0d82e43f07db8157ae8cf534571dd2ba48fbe31bbd658d89e2e24c0e38617d9c409cd5a2a88ce1db7d113075790e6b6e51c030ea8252c
-  languageName: node
-  linkType: hard
-
 "compute-scroll-into-view@npm:^3.0.2":
   version: 3.1.1
   resolution: "compute-scroll-into-view@npm:3.1.1"
@@ -6049,13 +6038,6 @@ __metadata:
   version: 1.1.1
   resolution: "ee-first@npm:1.1.1"
   checksum: 10c0/b5bb125ee93161bc16bfe6e56c6b04de5ad2aa44234d8f644813cc95d861a6910903132b05093706de2b706599367c4130eb6d170f6b46895686b95f87d017b7
-  languageName: node
-  linkType: hard
-
-"efrt@npm:2.7.0":
-  version: 2.7.0
-  resolution: "efrt@npm:2.7.0"
-  checksum: 10c0/c8f8e838e6e4efae7105a8349db2c9d7ad7a14a69982628c740fdaf7658c44866a6b988a6c9abda8d2f0f9ccbfe943ec38e35a6355873f9b7cb58ae87575f355
   languageName: node
   linkType: hard
 
@@ -7225,13 +7207,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"grad-school@npm:0.0.5":
-  version: 0.0.5
-  resolution: "grad-school@npm:0.0.5"
-  checksum: 10c0/c7b8a4681efe00d279ec3d24b4570492891c7b33ae0c6d038b762888fb3348082bb366c402b892c6f04b3345a9ee2f0f03c835738480331c068f336974f11732
-  languageName: node
-  linkType: hard
-
 "graphemer@npm:^1.4.0":
   version: 1.4.0
   resolution: "graphemer@npm:1.4.0"
@@ -7266,7 +7241,6 @@ __metadata:
     "@vitest/coverage-v8": "npm:3.1.3"
     autoprefixer: "npm:^10.4.21"
     browser-image-compression: "npm:^2.0.2"
-    compromise: "npm:^14.14.4"
     date-fns: "npm:^4.1.0"
     eslint: "npm:^9.26.0"
     eslint-config-prettier: "npm:^10.1.2"
@@ -10393,13 +10367,6 @@ __metadata:
     sucrase: bin/sucrase
     sucrase-node: bin/sucrase-node
   checksum: 10c0/ac85f3359d2c2ecbf5febca6a24ae9bf96c931f05fde533c22a94f59c6a74895e5d5f0e871878dfd59c2697a75ebb04e4b2224ef0bfc24ca1210735c2ec191ef
-  languageName: node
-  linkType: hard
-
-"suffix-thumb@npm:5.0.2":
-  version: 5.0.2
-  resolution: "suffix-thumb@npm:5.0.2"
-  checksum: 10c0/21013f81dbcca00db2081c69571b652ad23820735b4a9717ef138fc74cd12f1ead37304441698c6b562ba8e56222ed2b1a7ef8cfb89aa116f4684c1097c43bb6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`compromise` package takes too much space (614.51KiB in Rollup visualizer diagram), but adds too little value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the "compromise" dependency to streamline the application.

- **Refactor**
  - Updated verb past tense generation to use simple string manipulation instead of an external library.
  - Adjusted build configuration to create a separate chunk for 'phosphor-icons' and broadened chunking for motion-related modules, improving asset organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->