### PR TITLE
refactor: use unified bound zustand store

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@heroui/react": "^2.8.5",
     "@internationalized/date": "^3.10.0",
     "@phosphor-icons/react": "^2.1.10",
+    "@redux-devtools/extension": "^3.3.0",
     "@supabase/supabase-js": "^2.87.1",
     "@vercel/analytics": "^1.6.1",
     "browser-image-compression": "^2.0.2",

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -118,6 +118,7 @@ const WeekCalendar = () => {
     void fetchOccurrences(nextRange);
     void fetchNotes([rangeStart, toCalendarDate(rangeEnd)]);
   }, [
+    changeCalendarRange,
     firstDayOfWeek,
     fetchNotes,
     state.timeZone,

--- a/src/hooks/use-session.ts
+++ b/src/hooks/use-session.ts
@@ -79,11 +79,13 @@ const useSession = () => {
   }, [
     range,
     setUser,
-    fetchTraits,
-    fetchHabits,
-    clearTraits,
-    clearHabits,
+    fetchNotes,
     clearNotes,
+    fetchTraits,
+    clearTraits,
+    fetchHabits,
+    clearHabits,
+    fetchOccurrences,
     clearOccurrences,
   ]);
 };

--- a/src/stores/bound.store.ts
+++ b/src/stores/bound.store.ts
@@ -1,0 +1,49 @@
+import {
+  create,
+  type StateCreator,
+  type StoreMutatorIdentifier,
+} from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+
+import { type HabitsSlice, createHabitsSlice } from './habits.store';
+import { type NotesSlice, createNotesSlice } from './notes.store';
+import {
+  type OccurrencesSlice,
+  createOccurrencesSlice,
+} from './occurrences.store';
+import { type TraitsSlice, createTraitsSlice } from './traits.store';
+import { type UiSlice, createUiSlice } from './ui.store';
+import { type UserSlice, createUserSlice } from './user.store';
+
+export type ImmerStateCreator<
+  T,
+  Mps extends [StoreMutatorIdentifier, unknown][] = [],
+  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
+> = StateCreator<T, [...Mps, ['zustand/immer', never]], Mcs>;
+
+export type BoundStore = UserSlice &
+  UiSlice &
+  NotesSlice &
+  TraitsSlice &
+  HabitsSlice &
+  OccurrencesSlice;
+
+export type SliceCreator<TSlice extends keyof BoundStore> = (
+  ...params: Parameters<ImmerStateCreator<BoundStore>>
+) => Pick<ReturnType<ImmerStateCreator<BoundStore>>, TSlice>;
+
+export const useBoundStore = create<BoundStore>()(
+  devtools(
+    immer((set, get, store) => {
+      return {
+        ...createUiSlice(set, get, store),
+        ...createUserSlice(set, get, store),
+        ...createNotesSlice(set, get, store),
+        ...createTraitsSlice(set, get, store),
+        ...createHabitsSlice(set, get, store),
+        ...createOccurrencesSlice(set, get, store),
+      };
+    })
+  )
+);

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,3 +1,4 @@
+export * from './bound.store';
 export * from './habits.store';
 export * from './notes.store';
 export * from './occurrences.store';

--- a/src/stores/occurrences.store.ts
+++ b/src/stores/occurrences.store.ts
@@ -4,8 +4,6 @@ import {
   toCalendarDateTime,
 } from '@internationalized/date';
 import keyBy from 'lodash.keyby';
-import { create } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
 import { useShallow } from 'zustand/react/shallow';
 
 import type {
@@ -21,9 +19,11 @@ import {
   destroyOccurrence,
 } from '@services';
 
-type OccurrencesState = {
+import { useBoundStore, type SliceCreator } from './bound.store';
+
+export type OccurrencesSlice = {
   occurrences: Record<Occurrence['id'], Occurrence>;
-  actions: {
+  occurrencesActions: {
     addOccurrence: (occurrence: OccurrencesInsert) => Promise<Occurrence>;
     clearOccurrences: () => void;
     fetchOccurrences: (range: [number, number]) => Promise<void>;
@@ -39,87 +39,87 @@ type OccurrencesState = {
   };
 };
 
-const useOccurrencesStore = create<OccurrencesState>()(
-  immer((set) => {
-    return {
-      occurrences: {},
+export const createOccurrencesSlice: SliceCreator<keyof OccurrencesSlice> = (
+  set
+) => {
+  return {
+    occurrences: {},
 
-      actions: {
-        addOccurrence: async (occurrence: OccurrencesInsert) => {
-          const nextOccurrence = await createOccurrence(occurrence);
+    occurrencesActions: {
+      addOccurrence: async (occurrence: OccurrencesInsert) => {
+        const nextOccurrence = await createOccurrence(occurrence);
 
-          set((state) => {
-            state.occurrences[nextOccurrence.id] = nextOccurrence;
-          });
+        set((state) => {
+          state.occurrences[nextOccurrence.id] = nextOccurrence;
+        });
 
-          return nextOccurrence;
-        },
-
-        clearOccurrences: () => {
-          set((state) => {
-            state.occurrences = {};
-          });
-        },
-
-        fetchOccurrences: async (range: [number, number]) => {
-          const occurrences = await listOccurrences(range);
-
-          const occurrencesWithCalendarDateTime = occurrences.map(
-            (occurrence) => {
-              return {
-                ...occurrence,
-                occurredAt: toCalendarDateTime(
-                  fromDate(new Date(occurrence.timestamp), getLocalTimeZone())
-                ),
-              };
-            }
-          );
-
-          set((state) => {
-            state.occurrences = keyBy(occurrencesWithCalendarDateTime, 'id');
-          });
-        },
-
-        removeOccurrence: async (occurrence: Occurrence) => {
-          await destroyOccurrence(occurrence);
-
-          set((state) => {
-            delete state.occurrences[occurrence.id];
-          });
-        },
-
-        setOccurrenceNote: (
-          occurrenceId: Occurrence['id'],
-          note: Pick<Note, 'id' | 'content'> | null
-        ) => {
-          set((state) => {
-            const occurrence = state.occurrences[occurrenceId];
-
-            if (!occurrence) {
-              return;
-            }
-
-            occurrence.note = note;
-          });
-        },
-
-        updateOccurrence: async (
-          id: Occurrence['id'],
-          body: OccurrencesUpdate
-        ) => {
-          const updatedOccurrence = await patchOccurrence(id, body);
-
-          set((state) => {
-            state.occurrences[id] = updatedOccurrence;
-          });
-        },
+        return nextOccurrence;
       },
-    };
-  })
-);
+
+      clearOccurrences: () => {
+        set((state) => {
+          state.occurrences = {};
+        });
+      },
+
+      fetchOccurrences: async (range: [number, number]) => {
+        const occurrences = await listOccurrences(range);
+
+        const occurrencesWithCalendarDateTime = occurrences.map(
+          (occurrence) => {
+            return {
+              ...occurrence,
+              occurredAt: toCalendarDateTime(
+                fromDate(new Date(occurrence.timestamp), getLocalTimeZone())
+              ),
+            };
+          }
+        );
+
+        set((state) => {
+          state.occurrences = keyBy(occurrencesWithCalendarDateTime, 'id');
+        });
+      },
+
+      removeOccurrence: async (occurrence: Occurrence) => {
+        await destroyOccurrence(occurrence);
+
+        set((state) => {
+          delete state.occurrences[occurrence.id];
+        });
+      },
+
+      setOccurrenceNote: (
+        occurrenceId: Occurrence['id'],
+        note: Pick<Note, 'id' | 'content'> | null
+      ) => {
+        set((state) => {
+          const occurrence = state.occurrences[occurrenceId];
+
+          if (!occurrence) {
+            return;
+          }
+
+          occurrence.note = note;
+        });
+      },
+
+      updateOccurrence: async (
+        id: Occurrence['id'],
+        body: OccurrencesUpdate
+      ) => {
+        const updatedOccurrence = await patchOccurrence(id, body);
+
+        set((state) => {
+          state.occurrences[id] = updatedOccurrence;
+        });
+      },
+    },
+  };
+};
 
 export const useOccurrences = () => {
-  return useOccurrencesStore(
+  return useBoundStore(
     useShallow((state) => {
       return Object.values(state.occurrences);
     })
@@ -127,7 +127,7 @@ export const useOccurrences = () => {
 };
 
 export const useOccurrenceActions = () => {
-  return useOccurrencesStore((state) => {
-    return state.actions;
+  return useBoundStore((state) => {
+    return state.occurrencesActions;
   });
 };

--- a/src/stores/traits.store.ts
+++ b/src/stores/traits.store.ts
@@ -1,59 +1,57 @@
 import keyBy from 'lodash.keyby';
-import { create } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
 
 import type { Trait, TraitsInsert } from '@models';
 import { listTraits, createTrait } from '@services';
 
-type TraitsState = {
+import { useBoundStore, type SliceCreator } from './bound.store';
+
+export type TraitsSlice = {
   traits: Record<Trait['id'], Trait>;
-  actions: {
+  traitActions: {
     addTrait: (trait: TraitsInsert) => Promise<void>;
     clearTraits: () => void;
     fetchTraits: () => Promise<void>;
   };
 };
 
-const useTraitsStore = create<TraitsState>()(
-  immer((set) => {
-    return {
-      traits: {},
+export const createTraitsSlice: SliceCreator<keyof TraitsSlice> = (set) => {
+  return {
+    traits: {},
 
-      actions: {
-        addTrait: async (trait: TraitsInsert) => {
-          const newTrait = await createTrait(trait);
+    traitActions: {
+      addTrait: async (trait: TraitsInsert) => {
+        const newTrait = await createTrait(trait);
 
-          set((state) => {
-            state.traits[newTrait.id] = newTrait;
-          });
-        },
-
-        clearTraits: () => {
-          set((state) => {
-            state.traits = {};
-          });
-        },
-
-        fetchTraits: async () => {
-          const traits = await listTraits();
-
-          set((state) => {
-            state.traits = keyBy(traits, 'id');
-          });
-        },
+        set((state) => {
+          state.traits[newTrait.id] = newTrait;
+        });
       },
-    };
-  })
-);
+
+      clearTraits: () => {
+        set((state) => {
+          state.traits = {};
+        });
+      },
+
+      fetchTraits: async () => {
+        const traits = await listTraits();
+
+        set((state) => {
+          state.traits = keyBy(traits, 'id');
+        });
+      },
+    },
+  };
+};
 
 export const useTraits = () => {
-  return useTraitsStore((state) => {
+  return useBoundStore((state) => {
     return state.traits;
   });
 };
 
 export const useTraitActions = () => {
-  return useTraitsStore((state) => {
-    return state.actions;
+  return useBoundStore((state) => {
+    return state.traitActions;
   });
 };

--- a/src/stores/user.store.ts
+++ b/src/stores/user.store.ts
@@ -1,12 +1,12 @@
 import type { User, AuthError, UserAttributes } from '@supabase/supabase-js';
 import type { CamelCasedPropertiesDeep } from 'type-fest';
-import { create } from 'zustand';
-import { immer } from 'zustand/middleware/immer';
 import { useShallow } from 'zustand/react/shallow';
 
 import { updateUser } from '@services';
 
-type UserState = {
+import { useBoundStore, type SliceCreator } from './bound.store';
+
+export type UserSlice = {
   error: AuthError | null;
   isLoading: boolean;
   user: null | CamelCasedPropertiesDeep<User>;
@@ -23,77 +23,78 @@ type UserState = {
   };
 };
 
-const useUserStore = create<UserState>()(
-  immer((set, getState) => {
-    return {
-      error: null,
-      isLoading: true,
-      user: null,
-      actions: {
-        setError: (error) => {
-          set((state) => {
-            state.error = error;
-          });
-        },
-        setIsLoading: (isLoading) => {
-          set((state) => {
-            state.isLoading = isLoading;
-          });
-        },
-        setUser: (user) => {
-          set((state) => {
-            state.user = user;
-          });
-        },
-        updateUser: async (opts) => {
-          const { user } = getState();
-
-          if (!user) {
-            return;
-          }
-
-          const userAttributes: UserAttributes = {};
-
-          if (opts.email !== user.email) {
-            userAttributes.email = opts.email;
-          }
-
-          if (opts.password) {
-            userAttributes.password = opts.password;
-          }
-
-          const userMetadata: Record<string, string | number> = {};
-
-          if (
-            opts.firstDayOfWeek &&
-            opts.firstDayOfWeek !== user.userMetadata.firstDayOfWeek?.toString()
-          ) {
-            userMetadata.firstDayOfWeek = Number(opts.firstDayOfWeek);
-          }
-
-          if (opts.name && opts.name !== user.userMetadata.name) {
-            userMetadata.name = opts.name;
-          }
-
-          if (Object.keys(userMetadata).length > 0) {
-            userAttributes.data = userMetadata;
-          }
-
-          const updatedUser = await updateUser(userAttributes);
-
-          set((state) => {
-            state.user = { ...state.user, ...updatedUser };
-          });
-
-          return updatedUser;
-        },
+export const createUserSlice: SliceCreator<keyof UserSlice> = (
+  set,
+  getState
+) => {
+  return {
+    error: null,
+    isLoading: true,
+    user: null,
+    actions: {
+      setError: (error) => {
+        set((state) => {
+          state.error = error;
+        });
       },
-    };
-  })
-);
+      setIsLoading: (isLoading) => {
+        set((state) => {
+          state.isLoading = isLoading;
+        });
+      },
+      setUser: (user) => {
+        set((state) => {
+          state.user = user;
+        });
+      },
+      updateUser: async (opts) => {
+        const { user } = getState();
+
+        if (!user) {
+          return;
+        }
+
+        const userAttributes: UserAttributes = {};
+
+        if (opts.email !== user.email) {
+          userAttributes.email = opts.email;
+        }
+
+        if (opts.password) {
+          userAttributes.password = opts.password;
+        }
+
+        const userMetadata: Record<string, string | number> = {};
+
+        if (
+          opts.firstDayOfWeek &&
+          opts.firstDayOfWeek !== user.userMetadata.firstDayOfWeek?.toString()
+        ) {
+          userMetadata.firstDayOfWeek = Number(opts.firstDayOfWeek);
+        }
+
+        if (opts.name && opts.name !== user.userMetadata.name) {
+          userMetadata.name = opts.name;
+        }
+
+        if (Object.keys(userMetadata).length > 0) {
+          userAttributes.data = userMetadata;
+        }
+
+        const updatedUser = await updateUser(userAttributes);
+
+        set((state) => {
+          state.user = { ...state.user, ...updatedUser };
+        });
+
+        return updatedUser;
+      },
+    },
+  };
+};
 
 export const useUser = () => {
-  return useUserStore(
+  return useBoundStore(
     useShallow((state) => {
       return {
         error: state.error,
@@ -105,7 +106,7 @@ export const useUser = () => {
 };
 
 export const useUserActions = () => {
-  return useUserStore((state) => {
+  return useBoundStore((state) => {
     return state.actions;
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,6 +260,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.23.2":
+  version: 7.28.6
+  resolution: "@babel/runtime@npm:7.28.6"
+  checksum: 10c0/358cf2429992ac1c466df1a21c1601d595c46930a13c1d4662fde908d44ee78ec3c183aaff513ecb01ef8c55c3624afe0309eeeb34715672dbfadb7feedb2c0d
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/template@npm:7.27.2"
@@ -4026,6 +4033,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@redux-devtools/extension@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@redux-devtools/extension@npm:3.3.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.2"
+    immutable: "npm:^4.3.4"
+  peerDependencies:
+    redux: ^3.1.0 || ^4.0.0 || ^5.0.0
+  checksum: 10c0/a582d26687fdcbb9fc98181a6a28c7e286a6a74f35f5bba181b9b8b766029d34754bd8f8e60acaa757a34aca385056783d2efb95f943282f2ee66039931c942f
+  languageName: node
+  linkType: hard
+
 "@relative-ci/agent@npm:^4.3.1":
   version: 4.3.1
   resolution: "@relative-ci/agent@npm:4.3.1"
@@ -6892,6 +6911,7 @@ __metadata:
     "@heroui/react": "npm:^2.8.5"
     "@internationalized/date": "npm:^3.10.0"
     "@phosphor-icons/react": "npm:^2.1.10"
+    "@redux-devtools/extension": "npm:^3.3.0"
     "@relative-ci/agent": "npm:^4.3.1"
     "@stylistic/eslint-plugin": "npm:^5.6.1"
     "@supabase/supabase-js": "npm:^2.87.1"
@@ -7118,6 +7138,13 @@ __metadata:
   version: 11.0.1
   resolution: "immer@npm:11.0.1"
   checksum: 10c0/d505c1aa6d5d7ff03196e0a508af2853839eb1a3d5af51d55ca5815c46981b74765faf357fbd276b151109b07dd6b564077be92b0247b0a4effa78130166030d
+  languageName: node
+  linkType: hard
+
+"immutable@npm:^4.3.4":
+  version: 4.3.7
+  resolution: "immutable@npm:4.3.7"
+  checksum: 10c0/9b099197081b22f6433003e34929da8ecddbbdc1474cdc8aa3b7669dee4adda349c06143de22def36016d1b6de5322b043eccd7a11db1dad2ca85dad4fff5435
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Introduced a new `bound.store.ts` to centralize Zustand store slices and refactored all feature stores (habits, notes, occurrences, traits, user, ui) to use this unified store. Updated hooks and action naming for consistency. Added `@redux-devtools/extension` as a dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added Redux DevTools Extension dependency to support enhanced debugging capabilities
* Refactored internal state management architecture for improved code organization and maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->