### PR TITLE
feat(calendar): cache occurrences and notes within fetched range

### DIFF
--- a/src/services/notes.service.ts
+++ b/src/services/notes.service.ts
@@ -1,4 +1,4 @@
-import type { CalendarDateTime } from '@internationalized/date';
+import type { ZonedDateTime } from '@internationalized/date';
 import camelcaseKeys from 'camelcase-keys';
 import decamelizeKeys from 'decamelize-keys';
 
@@ -21,11 +21,11 @@ export const createNote = async (note: NotesInsert): Promise<Note> => {
 };
 
 export const listNotes = async ([rangeStart, rangeEnd]: [
-  CalendarDateTime,
-  CalendarDateTime,
+  ZonedDateTime,
+  ZonedDateTime,
 ]): Promise<Note[]> => {
-  const startDateString = rangeStart.toString();
-  const endDateString = rangeEnd.toString();
+  const startDateString = rangeStart.toAbsoluteString();
+  const endDateString = rangeEnd.toAbsoluteString();
 
   const periodNotesPromise = supabaseClient
     .from('notes')


### PR DESCRIPTION
Skip redundant API calls when navigating from a wider range (month) to a narrower one (week/day) by tracking the last fetched range and checking containment before fetching. occurrences are re-indexed in memory on cache hit; notes skip the fetch entirely. mutations invalidate the cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Added smart caching for notes and occurrences data, reducing unnecessary server requests when reviewing previously loaded date ranges.

* **Bug Fixes**
  * Improved timezone handling for date operations to ensure consistent accuracy across different time zones.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->