### PR TITLE
fix(calendar): defer range change until focused date is initialized

### DIFF
--- a/src/components/calendar/DayCalendar.tsx
+++ b/src/components/calendar/DayCalendar.tsx
@@ -50,14 +50,33 @@ const DayCalendar = () => {
   const { firstDayOfWeek } = useFirstDayOfWeek();
   const { locale } = useLocale();
   const timeZone = getLocalTimeZone();
+  const [focusedDate, setFocusedDate] = React.useState(() => {
+    return today(timeZone);
+  });
+  const [isFocusedDateInitialized, setIsFocusedDateInitialized] =
+    React.useState(false);
 
   const formatter = useDateFormatter({
     dateStyle: 'full',
   });
 
-  const [focusedDate, setFocusedDate] = React.useState(() => {
-    return today(timeZone);
-  });
+  React.useEffect(() => {
+    if (!isFocusedDateInitialized) {
+      return;
+    }
+
+    const focusedDateTime = toCalendarDateTime(focusedDate);
+
+    const rangeStart = focusedDateTime;
+    const rangeEnd = focusedDateTime.set({
+      hour: 23,
+      millisecond: 999,
+      minute: 59,
+      second: 59,
+    });
+
+    changeCalendarRange([rangeStart, rangeEnd]);
+  }, [focusedDate, changeCalendarRange, isFocusedDateInitialized]);
 
   React.useEffect(() => {
     const currentDay = today(timeZone);
@@ -76,22 +95,9 @@ const DayCalendar = () => {
 
     if (focusedDate.toString() !== paramsDate.toString()) {
       setFocusedDate(toCalendarDate(paramsDate));
+      setIsFocusedDateInitialized(true);
     }
   }, [params, timeZone, focusedDate]);
-
-  React.useEffect(() => {
-    const focusedDateTime = toCalendarDateTime(focusedDate);
-
-    const rangeStart = focusedDateTime;
-    const rangeEnd = focusedDateTime.set({
-      hour: 23,
-      millisecond: 999,
-      minute: 59,
-      second: 59,
-    });
-
-    changeCalendarRange([rangeStart, rangeEnd]);
-  }, [focusedDate, changeCalendarRange]);
 
   const dayNote = React.useMemo(() => {
     return dayNotes.find((note) => {

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -29,8 +29,14 @@ const MonthCalendar = ({ state }: MonthCalendarProps) => {
   const params = useParams();
   const { locale } = useLocale();
   const { firstDayOfWeek } = useFirstDayOfWeek();
+  const [isFocusedDateInitialized, setIsFocusedDateInitialized] =
+    React.useState(false);
 
   React.useEffect(() => {
+    if (!isFocusedDateInitialized) {
+      return;
+    }
+
     const focusedDateTime = toCalendarDateTime(state.focusedDate);
 
     const rangeStart = startOfWeek(
@@ -50,7 +56,13 @@ const MonthCalendar = ({ state }: MonthCalendarProps) => {
     });
 
     changeCalendarRange([rangeStart, rangeEnd]);
-  }, [state.focusedDate, firstDayOfWeek, changeCalendarRange, locale]);
+  }, [
+    state.focusedDate,
+    firstDayOfWeek,
+    changeCalendarRange,
+    locale,
+    isFocusedDateInitialized,
+  ]);
 
   React.useEffect(() => {
     const currentMonth = startOfMonth(today(state.timeZone));
@@ -69,6 +81,7 @@ const MonthCalendar = ({ state }: MonthCalendarProps) => {
 
     if (state.focusedDate.toString() !== paramsDate.toString()) {
       state.setFocusedDate(toCalendarDate(paramsDate));
+      setIsFocusedDateInitialized(true);
     }
   }, [params, state]);
 

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -48,6 +48,8 @@ const WeekCalendar = () => {
   const now = useCurrentTime();
   const changeCalendarRange = useCalendarRangeChange();
   const dayNotes = useDayNotes();
+  const [isFocusedDateInitialized, setIsFocusedDateInitialized] =
+    React.useState(false);
   const { isDesktop } = useScreenWidth();
   const { openNoteDrawer } = useNoteDrawerActions();
   const { openOccurrenceDrawer } = useOccurrenceDrawerActions();
@@ -71,6 +73,10 @@ const WeekCalendar = () => {
   );
 
   React.useEffect(() => {
+    if (!isFocusedDateInitialized) {
+      return;
+    }
+
     const focusedDateTime = toCalendarDateTime(state.focusedDate);
 
     const rangeStart = startOfWeek(focusedDateTime, locale, firstDayOfWeek);
@@ -82,7 +88,13 @@ const WeekCalendar = () => {
     });
 
     changeCalendarRange([rangeStart, rangeEnd]);
-  }, [state.focusedDate, firstDayOfWeek, changeCalendarRange, locale]);
+  }, [
+    state.focusedDate,
+    firstDayOfWeek,
+    changeCalendarRange,
+    locale,
+    isFocusedDateInitialized,
+  ]);
 
   React.useEffect(() => {
     const currentWeek = startOfWeek(
@@ -105,6 +117,7 @@ const WeekCalendar = () => {
 
     if (state.focusedDate.toString() !== paramsDate.toString()) {
       state.setFocusedDate(toCalendarDate(paramsDate));
+      setIsFocusedDateInitialized(true);
     }
   }, [state, params, locale, firstDayOfWeek]);
 


### PR DESCRIPTION
Prevent premature data fetching on mount by gating the changeCalendarRange effect behind an isFocusedDateInitialized flag in day, week, and month views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar initialization timing to ensure date ranges are properly calculated after component initialization completes, preventing incorrect date displays on initial load.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->