### PR TITLE
refactor: use included metric data in occurrence list item

### DIFF
--- a/src/components/calendar/DayCalendar.tsx
+++ b/src/components/calendar/DayCalendar.tsx
@@ -65,7 +65,7 @@ const DayCalendar = () => {
   });
 
   React.useEffect(() => {
-    if (!isFocusedDateInitialized) {
+    if (!isFocusedDateInitialized && focusedDate.day !== 1) {
       return;
     }
 

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -33,7 +33,7 @@ const MonthCalendar = ({ state }: MonthCalendarProps) => {
     React.useState(false);
 
   React.useEffect(() => {
-    if (!isFocusedDateInitialized) {
+    if (!isFocusedDateInitialized && state.focusedDate.day !== 1) {
       return;
     }
 

--- a/src/models/habit.model.ts
+++ b/src/models/habit.model.ts
@@ -2,12 +2,15 @@ import type { CamelCasedPropertiesDeep } from 'type-fest';
 
 import type { Tables, TablesInsert, TablesUpdate } from '@db-types';
 
+import type { HabitMetric } from './metric.model';
 import { type Trait } from './trait.model';
 
 type BaseHabit = CamelCasedPropertiesDeep<Tables<'habits'>>;
 
 export type Habit = BaseHabit & {
   trait: Pick<Trait, 'name' | 'color'>;
+} & {
+  metricDefinitions: Omit<HabitMetric, 'habitId' | 'userId'>[];
 };
 
 export type HabitsInsert = CamelCasedPropertiesDeep<TablesInsert<'habits'>>;

--- a/src/models/occurrence.model.ts
+++ b/src/models/occurrence.model.ts
@@ -9,20 +9,24 @@ import type {
 } from '@db-types';
 
 import { type Habit } from './habit.model';
+import type { OccurrenceMetricValue } from './metric.model';
 import { type Trait } from './trait.model';
 
 export type Streak = CamelCasedPropertiesDeep<CompositeTypes<'streak_info'>>;
 
 type BaseOccurrence = CamelCasedPropertiesDeep<Tables<'occurrences'>>;
 
-type OccurrenceHabit = Pick<Habit, 'name' | 'iconPath'>;
-
-type HabitWithTrait = OccurrenceHabit & {
+type OccurrenceHabit = Pick<
+  Habit,
+  'name' | 'iconPath' | 'metricDefinitions'
+> & {
   trait: Pick<Trait, 'id' | 'name' | 'color'>;
 };
 
 export type RawOccurrence = BaseOccurrence & {
-  habit: HabitWithTrait;
+  habit: OccurrenceHabit;
+} & {
+  metricValues: Omit<OccurrenceMetricValue, 'userId' | 'occurrenceId'>[];
 };
 
 export type Occurrence = Omit<
@@ -41,8 +45,3 @@ export type OccurrencesInsert = CamelCasedPropertiesDeep<
 export type OccurrencesUpdate = CamelCasedPropertiesDeep<
   TablesUpdate<'occurrences'>
 >;
-
-export type OccurrenceFilters = {
-  habitIds: Set<string>;
-  traitIds: Set<string>;
-};

--- a/src/services/habits.service.ts
+++ b/src/services/habits.service.ts
@@ -1,4 +1,3 @@
-import camelcaseKeys from 'camelcase-keys';
 import decamelizeKeys from 'decamelize-keys';
 
 import {
@@ -8,33 +7,45 @@ import {
   type HabitsUpdate,
 } from '@models';
 import { uploadFile } from '@services';
-import { supabaseClient } from '@utils';
+import { supabaseClient, deepCamelcaseKeys, deepCamelcaseArray } from '@utils';
 
 export const createHabit = async (body: HabitsInsert): Promise<Habit> => {
   const { data, error } = await supabaseClient
     .from('habits')
     .insert(decamelizeKeys(body))
-    .select('*, trait:traits(name, color)')
+    .select(
+      `
+      *,
+      trait:traits(name, color),
+      metric_definitions:habit_metrics(id, name, type, config, sort_order, is_required, created_at, updated_at)
+    `
+    )
     .single();
 
   if (error) {
     throw new Error(error.message);
   }
 
-  return camelcaseKeys(data, { deep: true });
+  return deepCamelcaseKeys<Habit>(data);
 };
 
 export const listHabits = async () => {
   const { data, error } = await supabaseClient
     .from('habits')
-    .select('*, trait:traits(id, name, color)')
+    .select(
+      `
+      *,
+      trait:traits(name, color),
+      metric_definitions:habit_metrics(id, name, type, config, sort_order, is_required, created_at, updated_at)
+    `
+    )
     .order('name');
 
   if (error) {
     throw new Error(error.message);
   }
 
-  return camelcaseKeys(data, { deep: true });
+  return deepCamelcaseArray<Habit>(data);
 };
 
 export const patchHabit = async (
@@ -45,14 +56,20 @@ export const patchHabit = async (
     .from('habits')
     .update(decamelizeKeys(habit))
     .eq('id', id)
-    .select('*, trait:traits(id, name, color)')
+    .select(
+      `
+      *,
+      trait:traits(name, color),
+      metric_definitions:habit_metrics(id, name, type, config, sort_order, is_required, created_at, updated_at)
+    `
+    )
     .single();
 
   if (error) {
     throw new Error(error.message);
   }
 
-  return camelcaseKeys(data, { deep: true });
+  return deepCamelcaseKeys<Habit>(data);
 };
 
 export const destroyHabit = async (id: Habit['id']) => {

--- a/src/services/metrics.service.ts
+++ b/src/services/metrics.service.ts
@@ -1,4 +1,3 @@
-import camelcaseKeys from 'camelcase-keys';
 import decamelizeKeys from 'decamelize-keys';
 
 import type {
@@ -8,10 +7,7 @@ import type {
   OccurrenceMetricValue,
   OccurrenceMetricValueInsert,
 } from '@models';
-import { supabaseClient } from '@utils';
-
-type SnakeRecord = Record<string, unknown>;
-type SnakeRecordArray = SnakeRecord[];
+import { supabaseClient, deepCamelcaseKeys, deepCamelcaseArray } from '@utils';
 
 export const createHabitMetric = async (
   body: HabitMetricInsert
@@ -26,7 +22,7 @@ export const createHabitMetric = async (
     throw new Error(error.message);
   }
 
-  return camelcaseKeys(data as SnakeRecord, { deep: true }) as HabitMetric;
+  return deepCamelcaseKeys<HabitMetric>(data);
 };
 
 export const listHabitMetrics = async (
@@ -42,9 +38,7 @@ export const listHabitMetrics = async (
     throw new Error(error.message);
   }
 
-  return camelcaseKeys(data as SnakeRecordArray, {
-    deep: true,
-  }) as HabitMetric[];
+  return deepCamelcaseArray<HabitMetric>(data);
 };
 
 export const patchHabitMetric = async (
@@ -62,7 +56,7 @@ export const patchHabitMetric = async (
     throw new Error(error.message);
   }
 
-  return camelcaseKeys(data as SnakeRecord, { deep: true }) as HabitMetric;
+  return deepCamelcaseKeys<HabitMetric>(data);
 };
 
 export const destroyHabitMetric = async (id: string) => {
@@ -88,9 +82,7 @@ export const listMetricValues = async (
     throw new Error(error.message);
   }
 
-  return camelcaseKeys(data as SnakeRecordArray, {
-    deep: true,
-  }) as OccurrenceMetricValue[];
+  return deepCamelcaseArray<OccurrenceMetricValue>(data);
 };
 
 export const upsertMetricValues = async (
@@ -116,9 +108,7 @@ export const upsertMetricValues = async (
     throw new Error(error.message);
   }
 
-  return camelcaseKeys(data as SnakeRecordArray, {
-    deep: true,
-  }) as OccurrenceMetricValue[];
+  return deepCamelcaseArray<OccurrenceMetricValue>(data);
 };
 
 export const destroyMetricValuesForOccurrence = async (

--- a/src/utils/camelcase.ts
+++ b/src/utils/camelcase.ts
@@ -1,0 +1,11 @@
+import camelcaseKeys from 'camelcase-keys';
+
+type SnakeRecord = Record<string, unknown>;
+
+export const deepCamelcaseKeys = <T>(data: unknown): T => {
+  return camelcaseKeys(data as SnakeRecord, { deep: true }) as T;
+};
+
+export const deepCamelcaseArray = <T>(data: unknown): T[] => {
+  return camelcaseKeys(data as SnakeRecord[], { deep: true }) as T[];
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './camelcase';
 export * from './date';
 export { default as getErrorMessage } from './get-error-message';
 export { default as handleAsyncAction } from './handle-async-action';

--- a/tests/makeTestHabit.ts
+++ b/tests/makeTestHabit.ts
@@ -6,6 +6,7 @@ const makeTestHabit = (override: Partial<Habit> = {}): Habit => {
     description: 'Test Description',
     iconPath: 'https://i.ibb.co/vvgw7bx/habitrack-logo.png',
     id: crypto.randomUUID(),
+    metricDefinitions: [],
     name: 'Test Habit',
     traitId: crypto.randomUUID(),
     updatedAt: null,

--- a/tests/makeTestOccurrence.ts
+++ b/tests/makeTestOccurrence.ts
@@ -8,6 +8,7 @@ const makeTestOccurrence = (override: Partial<Occurrence> = {}): Occurrence => {
     habitId: crypto.randomUUID(),
     hasSpecificTime: true,
     id: crypto.randomUUID(),
+    metricValues: [],
     occurredAt: now('Europe/Madrid'),
     photoPaths: [],
     timeZone: 'Europe/Madrid',
@@ -17,6 +18,7 @@ const makeTestOccurrence = (override: Partial<Occurrence> = {}): Occurrence => {
       iconPath: 'default.png',
       name: 'Test Habit Name',
       ...(override.habit || {}),
+      metricDefinitions: [],
       trait: {
         color: '#000000',
         id: override.habit?.trait?.id || crypto.randomUUID(),


### PR DESCRIPTION
Add deepCamelcaseKeys/deepCamelcaseArray helpers and export them from utils. Update habits, metrics and occurrences services to use these helpers and expand Supabase selects to include habit metric_definitions and occurrence metric_values so API responses are returned fully camelCased. Update models to surface metricDefinitions/metricValues on Habit and RawOccurrence, and adjust OccurrenceListItem to read metric definitions/values directly from the occurrence instead of store hooks. Small calendar effect guard fixes for focusedDate initialization and test factories updated to include empty metric arrays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized metric data retrieval and display in occurrences
  * Improved calendar initialization logic and timing
  * Standardized internal data transformation utilities

* **Tests**
  * Updated test data structures to align with refined data models

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->