### PR TITLE
refactor: use included metric definitions in metric values section

### DIFF
--- a/src/components/metric/MetricValuesSection.tsx
+++ b/src/components/metric/MetricValuesSection.tsx
@@ -1,99 +1,28 @@
-import { Spinner } from '@heroui/react';
-import React from 'react';
-
-import type { MetricValue, MetricConfig, OccurrenceMetricValue } from '@models';
-import {
-  useHabitMetrics,
-  useMetricsActions,
-  useOccurrenceMetricValues,
-} from '@stores';
+import type { Habit, MetricValue, MetricConfig } from '@models';
 
 import MetricValueInput from './MetricValueInput';
 
 type MetricValuesState = Record<string, MetricValue | undefined>;
 
 type MetricValuesSectionProps = {
-  habitId: string | undefined;
-  occurrenceId: string | undefined;
+  metricDefinitions: Habit['metricDefinitions'];
   values: MetricValuesState;
   onChange: (values: MetricValuesState) => void;
 };
 
 const MetricValuesSection = ({
-  habitId,
-  occurrenceId,
+  metricDefinitions,
   onChange,
   values,
 }: MetricValuesSectionProps) => {
-  const metrics = useHabitMetrics(habitId);
-  const { fetchHabitMetrics, fetchMetricValues } = useMetricsActions();
-  const existingValues = useOccurrenceMetricValues(occurrenceId);
-  const [isLoading, setIsLoading] = React.useState(false);
-  const [hasInitializedExisting, setHasInitializedExisting] =
-    React.useState(false);
-
-  React.useEffect(() => {
-    if (!habitId) {
-      return;
-    }
-
-    setIsLoading(true);
-    fetchHabitMetrics(habitId).finally(() => {
-      setIsLoading(false);
-    });
-  }, [habitId, fetchHabitMetrics]);
-
-  React.useEffect(() => {
-    if (!occurrenceId) {
-      return;
-    }
-
-    fetchMetricValues(occurrenceId);
-  }, [occurrenceId, fetchMetricValues]);
-
-  React.useEffect(() => {
-    if (hasInitializedExisting || !occurrenceId) {
-      return;
-    }
-
-    if (Object.keys(existingValues).length === 0) {
-      return;
-    }
-
-    const initial: MetricValuesState = {};
-
-    for (const [metricId, entry] of Object.entries(existingValues)) {
-      initial[metricId] = (entry as OccurrenceMetricValue).value as MetricValue;
-    }
-
-    onChange(initial);
-    setHasInitializedExisting(true);
-  }, [existingValues, hasInitializedExisting, occurrenceId, onChange]);
-
-  React.useEffect(() => {
-    setHasInitializedExisting(false);
-  }, [habitId]);
-
-  if (!habitId) {
-    return null;
-  }
-
-  if (isLoading) {
-    return (
-      <div className="flex justify-center py-2">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (metrics.length === 0) {
+  if (metricDefinitions.length === 0) {
     return null;
   }
 
   return (
     <div className="w-full space-y-3">
       <p className="text-foreground-500 text-tiny font-medium">Metrics</p>
-      {metrics.map((metric) => {
+      {metricDefinitions.map((metric) => {
         return (
           <MetricValueInput
             key={metric.id}

--- a/src/components/occurrence/OccurrenceForm.tsx
+++ b/src/components/occurrence/OccurrenceForm.tsx
@@ -92,6 +92,18 @@ const OccurrenceForm = ({
     Record<string, MetricValue | undefined>
   >({});
 
+  const metricDefinitions = React.useMemo(() => {
+    if (occurrenceToEdit) {
+      return occurrenceToEdit.habit.metricDefinitions;
+    }
+
+    if (selectedHabitId && habits[selectedHabitId]) {
+      return habits[selectedHabitId].metricDefinitions;
+    }
+
+    return [];
+  }, [occurrenceToEdit, selectedHabitId, habits]);
+
   const occurrenceNote = React.useMemo(() => {
     return notes[occurrenceToEdit?.id || ''];
   }, [notes, occurrenceToEdit]);
@@ -174,6 +186,14 @@ const OccurrenceForm = ({
       handleNoteChange(occurrenceNote?.content || '');
       setTime(existingOccurrenceDateTime);
       setHasSpecificTime(occurrenceToEdit.hasSpecificTime);
+
+      const initialMetricValues: Record<string, MetricValue | undefined> = {};
+
+      for (const mv of occurrenceToEdit.metricValues) {
+        initialMetricValues[mv.habitMetricId] = mv.value as MetricValue;
+      }
+
+      setMetricValues(initialMetricValues);
 
       return;
     }
@@ -514,8 +534,7 @@ const OccurrenceForm = ({
       <MetricValuesSection
         values={metricValues}
         onChange={setMetricValues}
-        occurrenceId={occurrenceToEdit?.id}
-        habitId={selectedHabitId || undefined}
+        metricDefinitions={metricDefinitions}
       />
       <Textarea
         value={note}


### PR DESCRIPTION
Remove internal store fetching from MetricValuesSection and make it accept metricDefinitions as a prop. Update OccurrenceForm to compute metricDefinitions (from occurrenceToEdit or selected habit) and to initialize metricValues when editing an occurrence. This simplifies MetricValuesSection by removing loading/fetching/effects and moves responsibility for providing metric defs and initial metric values to the parent form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Metric values section now uses direct data flow instead of fetch-based loading, removing loading indicators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->