### PR TITLE
refactor: use included metrics data in edit habit dialog

### DIFF
--- a/src/components/habit/EditHabitDialog.tsx
+++ b/src/components/habit/EditHabitDialog.tsx
@@ -20,7 +20,6 @@ import {
   useUser,
   useTraits,
   useHabitActions,
-  useHabitMetrics,
   useMetricsActions,
 } from '@stores';
 import { handleAsyncAction } from '@utils';
@@ -44,55 +43,47 @@ const EditHabitDialog = ({ habit, onClose }: EditHabitDialogProps) => {
   );
 
   const { updateHabit } = useHabitActions();
-  const {
-    addHabitMetric,
-    fetchHabitMetrics,
-    removeHabitMetric,
-    updateHabitMetric,
-  } = useMetricsActions();
-  const existingMetrics = useHabitMetrics(habit?.id);
+  const { addHabitMetric, removeHabitMetric, updateHabitMetric } =
+    useMetricsActions();
   const traits = useTraits();
   const { user } = useUser();
 
   React.useEffect(() => {
     if (habit) {
       onOpen();
-      void fetchHabitMetrics(habit.id);
     } else {
       onClose?.();
     }
-  }, [habit, onOpen, onClose, fetchHabitMetrics]);
+  }, [habit, onOpen, onClose]);
 
   React.useEffect(() => {
     if (habit) {
       handleNameChange(habit.name);
       handleDescriptionChange(habit.description || '');
       setTraitId(habit.traitId.toString());
-    }
-  }, [habit, handleNameChange, handleDescriptionChange]);
 
-  React.useEffect(() => {
-    if (existingMetrics.length > 0) {
-      const localMetrics: LocalMetricDefinition[] = existingMetrics.map((m) => {
-        return {
-          config: m.config as LocalMetricDefinition['config'],
-          id: m.id,
-          isRequired: m.isRequired,
-          name: m.name,
-          sortOrder: m.sortOrder,
-          type: m.type,
-        };
-      });
+      const localMetrics: LocalMetricDefinition[] = habit.metricDefinitions.map(
+        (m) => {
+          return {
+            config: m.config as LocalMetricDefinition['config'],
+            id: m.id,
+            isRequired: m.isRequired,
+            name: m.name,
+            sortOrder: m.sortOrder,
+            type: m.type,
+          };
+        }
+      );
       setMetricDefinitions(localMetrics);
       setInitialMetricIds(
         new Set(
-          existingMetrics.map((m) => {
+          habit.metricDefinitions.map((m) => {
             return m.id;
           })
         )
       );
     }
-  }, [existingMetrics]);
+  }, [habit, handleNameChange, handleDescriptionChange]);
 
   if (!habit) {
     return null;

--- a/src/stores/metrics.store.ts
+++ b/src/stores/metrics.store.ts
@@ -1,5 +1,4 @@
 import keyBy from 'lodash.keyby';
-import { useShallow } from 'zustand/react/shallow';
 
 import type {
   HabitMetric,
@@ -139,32 +138,6 @@ export const createMetricsSlice: SliceCreator<keyof MetricsSlice> = (
       },
     },
   };
-};
-
-export const useHabitMetrics = (habitId: string | undefined) => {
-  return useBoundStore(
-    useShallow((state) => {
-      if (!habitId || !state.habitMetrics[habitId]) {
-        return [];
-      }
-
-      return Object.values(state.habitMetrics[habitId]).sort((a, b) => {
-        return a.sortOrder - b.sortOrder;
-      });
-    })
-  );
-};
-
-export const useOccurrenceMetricValues = (occurrenceId: string | undefined) => {
-  return useBoundStore(
-    useShallow((state) => {
-      if (!occurrenceId || !state.occurrenceMetricValues[occurrenceId]) {
-        return {};
-      }
-
-      return state.occurrenceMetricValues[occurrenceId];
-    })
-  );
 };
 
 export const useMetricsActions = () => {


### PR DESCRIPTION
Remove useHabitMetrics and useOccurrenceMetricValues from the metrics store and drop the zustand shallow import. Update EditHabitDialog to stop fetching habit metrics and instead read metricDefinitions from the habit prop, simplify related effects, and wire metrics actions (add/remove/update) accordingly. This reduces redundant fetching and relies on the habit's embedded metric definitions for editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal metric data handling to improve system efficiency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->