### PR TITLE
refactor: embed metrics into habit and occurrence state

### DIFF
--- a/src/components/habit/HabitsTable.test.tsx
+++ b/src/components/habit/HabitsTable.test.tsx
@@ -24,8 +24,8 @@ vi.mock('@services', () => {
 
 vi.mock('@stores', () => {
   return {
-    useHabitMetrics: vi.fn().mockReturnValue({}),
     useHabits: vi.fn(),
+    useMetricsActions: vi.fn().mockReturnValue({}),
     useTraits: vi.fn().mockReturnValue({}),
     useUser: vi.fn().mockReturnValue({}),
     useConfirmationActions: vi.fn().mockReturnValue({
@@ -34,9 +34,6 @@ vi.mock('@stores', () => {
     useHabitActions: vi.fn().mockReturnValue({
       removeHabit: vi.fn(),
       updateHabit: vi.fn(),
-    }),
-    useMetricsActions: vi.fn().mockReturnValue({
-      fetchHabitMetrics: vi.fn(),
     }),
     useNoteActions: vi.fn().mockReturnValue({
       addNote: vi.fn(),

--- a/src/services/metrics.service.ts
+++ b/src/services/metrics.service.ts
@@ -25,22 +25,6 @@ export const createHabitMetric = async (
   return deepCamelcaseKeys<HabitMetric>(data);
 };
 
-export const listHabitMetrics = async (
-  habitId: string
-): Promise<HabitMetric[]> => {
-  const { data, error } = await supabaseClient
-    .from('habit_metrics')
-    .select()
-    .eq('habit_id', habitId)
-    .order('sort_order');
-
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  return deepCamelcaseArray<HabitMetric>(data);
-};
-
 export const patchHabitMetric = async (
   id: string,
   body: HabitMetricUpdate
@@ -68,21 +52,6 @@ export const destroyHabitMetric = async (id: string) => {
   if (error) {
     throw new Error(error.message);
   }
-};
-
-export const listMetricValues = async (
-  occurrenceId: string
-): Promise<OccurrenceMetricValue[]> => {
-  const { data, error } = await supabaseClient
-    .from('occurrence_metric_values')
-    .select()
-    .eq('occurrence_id', occurrenceId);
-
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  return deepCamelcaseArray<OccurrenceMetricValue>(data);
 };
 
 export const upsertMetricValues = async (

--- a/src/stores/bound.store.ts
+++ b/src/stores/bound.store.ts
@@ -62,17 +62,11 @@ useBoundStore.subscribe(
     };
   },
   (newState, prevState) => {
-    const {
-      habitActions,
-      metricsActions,
-      noteActions,
-      occurrencesActions,
-      traitActions,
-    } = useBoundStore.getState();
+    const { habitActions, noteActions, occurrencesActions, traitActions } =
+      useBoundStore.getState();
 
     if (!newState.userId && prevState.userId) {
       habitActions.clearHabits();
-      metricsActions.clearMetrics();
       traitActions.clearTraits();
       occurrencesActions.clearOccurrences();
       noteActions.clearNotes();


### PR DESCRIPTION
Refactor metrics handling by removing separate metric caches and embedding metric definitions/values directly on habit and occurrence objects. Key changes:

- metrics.store: remove habitMetrics and occurrenceMetricValues maps and related fetch/list methods; update add/remove/save/patch flows to mutate state.habits, state.occurrences and state.occurrencesByDate (using toCalendarDate) so metricDefinitions and metricValues live with their habits/occurrences.
- services: remove listHabitMetrics and listMetricValues API wrappers.
- DayCalendar: stop using bound store metric caches and metrics actions; derive totals and metric values from occurrence.metricValues and habit.metricDefinitions instead.
- bound.store: stop calling metricsActions.clearMetrics on user logout.
- tests: update HabitsTable.test to reflect new metrics API surface (mock useMetricsActions) and remove old mocks.

Rationale: simplify state model and eliminate redundant fetching/caching of metrics by keeping metric data colocated with the related habit/occurrence entities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal metrics data architecture for better efficiency and maintainability.
  * Simplified how the application stores and calculates metric values.
  * Consolidated metrics data structure to reduce complexity.

* **Tests**
  * Updated test suite to reflect changes in metrics handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->