### PR TITLE
refactor(occurrence): split form into update and create containers

### DIFF
--- a/src/components/occurrence/OccurrenceDrawer.tsx
+++ b/src/components/occurrence/OccurrenceDrawer.tsx
@@ -24,8 +24,9 @@ import {
 import { handleAsyncAction } from '@utils';
 
 import OccurrenceChip from './OccurrenceChip';
-import OccurrenceForm from './OccurrenceForm';
+import OccurrenceCreateFormContainer from './OccurrenceCreateFormContainer';
 import OccurrenceList from './OccurrenceList';
+import OccurrenceUpdateFormContainer from './OccurrenceUpdateFormContainer';
 
 const OccurrenceDrawer = () => {
   const timeZone = getLocalTimeZone();
@@ -206,7 +207,8 @@ const OccurrenceDrawer = () => {
               }
             />
           )}
-          {(dayToLog || occurrenceToEdit) && <OccurrenceForm />}
+          {dayToLog && <OccurrenceCreateFormContainer />}
+          {occurrenceToEdit && <OccurrenceUpdateFormContainer />}
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/components/occurrence/OccurrenceFormView.tsx
+++ b/src/components/occurrence/OccurrenceFormView.tsx
@@ -51,13 +51,13 @@ export type OccurrenceFormValues = {
 };
 
 type OccurrenceFormViewProps = {
-  dayToLog: CalendarDate | null;
+  dayToLog?: CalendarDate;
   habits: Record<string, Habit>;
   isSaving: boolean;
-  occurrenceNote: { content: string; id: string } | undefined;
-  occurrenceToEdit: Occurrence | null;
+  occurrenceNote?: { content: string; id: string };
+  occurrenceToEdit?: Occurrence;
   onClose: () => void;
-  onPhotoDelete: (path: string) => void;
+  onPhotoDelete?: (path: string) => void;
   onSubmit: (values: OccurrenceFormValues) => void;
 };
 
@@ -488,11 +488,13 @@ const OccurrenceFormView = ({
         onFilesChange={setUploadedFiles}
         photoPaths={occurrenceToEdit?.photoPaths || null}
       />
-      <SignedImageViewer
-        onDelete={onPhotoDelete}
-        bucket={StorageBuckets.OCCURRENCE_PHOTOS}
-        paths={occurrenceToEdit?.photoPaths || null}
-      />
+      {onPhotoDelete && (
+        <SignedImageViewer
+          onDelete={onPhotoDelete}
+          bucket={StorageBuckets.OCCURRENCE_PHOTOS}
+          paths={occurrenceToEdit?.photoPaths || null}
+        />
+      )}
       {hasHabits ? (
         <Button {...submitButtonSharedProps} fullWidth onPress={handleSubmit}>
           {occurrenceToEdit ? 'Update' : 'Add'}

--- a/src/components/occurrence/OccurrenceUpdateFormContainer.tsx
+++ b/src/components/occurrence/OccurrenceUpdateFormContainer.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+
+import type { MetricValue, OccurrenceMetricValueInsert } from '@models';
+import { StorageBuckets } from '@models';
+import { uploadImages } from '@services';
+import {
+  useUser,
+  useHabits,
+  useNoteActions,
+  useMetricsActions,
+  useOccurrenceActions,
+  useNotesByOccurrenceId,
+  useOccurrenceDrawerState,
+  useOccurrenceDrawerActions,
+} from '@stores';
+import { handleAsyncAction } from '@utils';
+
+import OccurrenceFormView, {
+  type OccurrenceFormValues,
+} from './OccurrenceFormView';
+
+const OccurrenceUpdateFormContainer = () => {
+  const { closeOccurrenceDrawer } = useOccurrenceDrawerActions();
+  const { occurrenceToEdit } = useOccurrenceDrawerState();
+  const { user } = useUser();
+  const habits = useHabits();
+  const notes = useNotesByOccurrenceId();
+  const [isSaving, setIsSaving] = React.useState(false);
+  const { addNote, deleteNote, updateNote } = useNoteActions();
+  const { updateOccurrence } = useOccurrenceActions();
+  const { saveMetricValues } = useMetricsActions();
+
+  const occurrenceNote = React.useMemo(() => {
+    return notes[occurrenceToEdit?.id || ''];
+  }, [notes, occurrenceToEdit]);
+
+  const buildMetricInserts = (
+    metricValues: Record<string, MetricValue | undefined>,
+    occurrenceId: string,
+    userId: string
+  ): OccurrenceMetricValueInsert[] => {
+    return Object.entries(metricValues)
+      .filter(([, val]) => {
+        return val !== undefined;
+      })
+      .map(([metricId, val]) => {
+        return {
+          habitMetricId: metricId,
+          occurrenceId,
+          userId,
+          value: val as MetricValue,
+        };
+      });
+  };
+
+  const handleSubmit = async (values: OccurrenceFormValues) => {
+    if (!user || !occurrenceToEdit) {
+      return;
+    }
+
+    const {
+      hasSpecificTime,
+      metricValues,
+      note,
+      occurredAt,
+      selectedHabitId,
+      uploadedFiles,
+    } = values;
+
+    setIsSaving(true);
+
+    const updatePromise = async () => {
+      const uploadedPhotoPaths = uploadedFiles.length
+        ? await uploadImages(
+            StorageBuckets.OCCURRENCE_PHOTOS,
+            user.id,
+            uploadedFiles,
+            selectedHabitId
+          )
+        : [];
+
+      const photoPaths = (occurrenceToEdit.photoPaths || []).concat(
+        uploadedPhotoPaths
+      );
+
+      await updateOccurrence(occurrenceToEdit, {
+        habitId: selectedHabitId,
+        hasSpecificTime,
+        occurredAt,
+        photoPaths: photoPaths.length ? photoPaths : null,
+        userId: user.id,
+      });
+
+      if (note) {
+        if (occurrenceNote) {
+          await updateNote(occurrenceNote.id, {
+            content: note,
+            occurrenceId: occurrenceToEdit.id,
+          });
+        } else {
+          await addNote({
+            content: note,
+            occurrenceId: occurrenceToEdit.id,
+            userId: user.id,
+          });
+        }
+      } else if (occurrenceNote) {
+        await deleteNote(occurrenceNote.id);
+      }
+
+      const metricInserts = buildMetricInserts(
+        metricValues,
+        occurrenceToEdit.id,
+        user.id
+      );
+
+      if (metricInserts.length > 0) {
+        await saveMetricValues(metricInserts);
+      }
+    };
+
+    void handleAsyncAction(
+      updatePromise(),
+      'update_occurrence',
+      setIsSaving
+    ).then(closeOccurrenceDrawer);
+  };
+
+  const handlePhotoDelete = (path: string) => {
+    if (!occurrenceToEdit?.photoPaths) {
+      return;
+    }
+
+    void updateOccurrence(occurrenceToEdit, {
+      photoPaths: occurrenceToEdit.photoPaths.filter((p) => {
+        return p !== path;
+      }),
+    });
+  };
+
+  if (!occurrenceToEdit) {
+    return null;
+  }
+
+  return (
+    <OccurrenceFormView
+      habits={habits}
+      isSaving={isSaving}
+      onSubmit={handleSubmit}
+      onClose={closeOccurrenceDrawer}
+      occurrenceNote={occurrenceNote}
+      onPhotoDelete={handlePhotoDelete}
+      occurrenceToEdit={occurrenceToEdit}
+    />
+  );
+};
+
+export default OccurrenceUpdateFormContainer;


### PR DESCRIPTION
Rename OccurrenceForm to OccurrenceCreateFormContainer and extract update logic into a new OccurrenceUpdateFormContainer. Update OccurrenceDrawer to render the create or update container based on dayToLog/occurrenceToEdit. Make OccurrenceFormView props more flexible (optional dayToLog, occurrenceToEdit, occurrenceNote, and optional onPhotoDelete) and render SignedImageViewer conditionally. This separates create vs. edit responsibilities, removes edit-specific hooks from the create container, and keeps view logic reusable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized occurrence form components to separate creation and editing workflows, improving internal code structure and maintainability with no changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->