### PR TITLE
fix: sync calendar filters with habit and trait changes

### DIFF
--- a/src/stores/habits.store.ts
+++ b/src/stores/habits.store.ts
@@ -33,6 +33,7 @@ export const createHabitsSlice: SliceCreator<keyof HabitsSlice> = (set) => {
 
         set((state) => {
           state.habits[newHabit.id] = newHabit;
+          state.calendarFilters.habitIds.push(newHabit.id);
         });
 
         return newHabit;
@@ -72,6 +73,10 @@ export const createHabitsSlice: SliceCreator<keyof HabitsSlice> = (set) => {
 
         set((state) => {
           delete state.habits[id];
+          state.calendarFilters.habitIds =
+            state.calendarFilters.habitIds.filter((habitId) => {
+              return habitId !== id;
+            });
         });
       },
 

--- a/src/stores/traits.store.ts
+++ b/src/stores/traits.store.ts
@@ -24,6 +24,7 @@ export const createTraitsSlice: SliceCreator<keyof TraitsSlice> = (set) => {
 
         set((state) => {
           state.traits[newTrait.id] = newTrait;
+          state.calendarFilters.traitIds.push(newTrait.id);
         });
       },
 


### PR DESCRIPTION
## Description

Keep calendarFilters in sync with created and deleted items. Append new habit/trait IDs to calendarFilters.habitIds/traitIds when created so they show up in calendar filters, and remove a habit ID from calendarFilters.habitIds when a habit is deleted to avoid stale references. Changes applied in src/stores/habits.store.ts and src/stores/traits.store.ts.

@coderabbitai ignore

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've updated documentation if needed
