### PR TITLE
feat(layout): move header actions into bottom bar on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ const App = () => {
         <NoteDrawer />
         <OccurrenceDrawer />
         <ConfirmationDialog />
-        <main className="bg-background-50 dark:bg-background-700 flex h-full flex-1 flex-col items-start">
+        <main className="bg-background-50 dark:bg-background-700 flex h-full flex-1 flex-col items-start max-md:pb-11.25">
           <Routes>
             <Route
               element={<MonthCalendarPage />}

--- a/src/components/calendar/CalendarNavigation.tsx
+++ b/src/components/calendar/CalendarNavigation.tsx
@@ -1,11 +1,7 @@
 import { useDisclosure, type Selection } from '@heroui/react';
 import { cn, Button, Select, SelectItem, SelectSection } from '@heroui/react';
-import { today, getLocalTimeZone } from '@internationalized/date';
-import {
-  NotePencilIcon,
-  FunnelSimpleIcon,
-  CalendarCheckIcon,
-} from '@phosphor-icons/react';
+import { getLocalTimeZone } from '@internationalized/date';
+import { FunnelSimpleIcon } from '@phosphor-icons/react';
 import capitalize from 'lodash.capitalize';
 import React from 'react';
 import { useDateFormatter } from 'react-aria';
@@ -13,13 +9,7 @@ import { useLocation, useNavigate } from 'react-router';
 import type { CalendarState } from 'react-stately';
 
 import { useScreenWidth, useFirstDayOfWeek } from '@hooks';
-import {
-  useUser,
-  useCalendarFilters,
-  useNoteDrawerActions,
-  useCalendarFiltersChange,
-  useOccurrenceDrawerActions,
-} from '@stores';
+import { useUser, useCalendarFilters, useCalendarFiltersChange } from '@stores';
 import { getWeeksOfYear } from '@utils';
 
 import CalendarNavigationButtons from './CalendarNavigationButtons';
@@ -65,8 +55,6 @@ const CalendarNavigation = ({ focusedDate }: MonthCalendarNavigationProps) => {
   const { isOpen: isWeekSelectOpen, onOpenChange: onWeekSelectOpenChange } =
     useDisclosure();
   const navigate = useNavigate();
-  const { openNoteDrawer } = useNoteDrawerActions();
-  const { openOccurrenceDrawer } = useOccurrenceDrawerActions();
   const { firstDayOfWeek } = useFirstDayOfWeek();
   const [weekSelectValue, setWeekSelectValue] = React.useState<Selection>(
     new Set([])
@@ -117,34 +105,6 @@ const CalendarNavigation = ({ focusedDate }: MonthCalendarNavigationProps) => {
 
   return (
     <div className="flex flex-col items-stretch justify-end gap-2 max-[445px]:gap-4 min-[446px]:flex-row lg:justify-between lg:gap-2">
-      <div className="flex w-full gap-2">
-        <Button
-          size="sm"
-          variant="flat"
-          color="secondary"
-          className="h-6 w-1/2 md:hidden"
-          onPress={() => {
-            openOccurrenceDrawer({
-              dayToLog: today(timeZone),
-            });
-          }}
-        >
-          <CalendarCheckIcon size={16} weight="bold" />
-          Log
-        </Button>
-        <Button
-          size="sm"
-          variant="flat"
-          color="secondary"
-          className="h-6 w-1/2 md:hidden"
-          onPress={() => {
-            openNoteDrawer(today(timeZone), 'day');
-          }}
-        >
-          <NotePencilIcon size={16} weight="bold" />
-          Note
-        </Button>
-      </div>
       <div className="mr-0 flex items-stretch gap-2 lg:mr-2">
         <Select
           size="sm"

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -12,7 +12,7 @@ import {
 import { Link, useLocation } from 'react-router';
 
 import { AuthModalButton } from '@components';
-import { useScreenWidth, useKeyboardShortcut } from '@hooks';
+import { useScreenWidth, useHasKeyboard, useKeyboardShortcut } from '@hooks';
 import { useNoteDrawerActions, useOccurrenceDrawerActions } from '@stores';
 
 import ThemeToggle from './ThemeToggle';
@@ -22,6 +22,7 @@ const Header = () => {
   const { pathname } = useLocation();
   const { openNoteDrawer } = useNoteDrawerActions();
   const { openOccurrenceDrawer } = useOccurrenceDrawerActions();
+  const hasKeyboard = useHasKeyboard();
 
   const dispatchNoteDrawerOpen = () => {
     openNoteDrawer(today(getLocalTimeZone()), 'day');
@@ -112,50 +113,72 @@ const Header = () => {
             </Tooltip>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          <Button
-            as={Link}
-            size="sm"
-            variant="solid"
-            target="_blank"
-            color="secondary"
-            rel="noopener noreferrer"
-            className="hidden md:inline-flex"
-            to="https://habitrack.featurebase.app/roadmap"
-          >
-            <ArrowSquareOutIcon size={16} weight="bold" />
-            Roadmap
-            <Kbd className="bg-secondary-300 dark:bg-secondary-700 hidden px-1 py-0 lg:block">
-              M
-            </Kbd>
-          </Button>
-          <Button
-            size="sm"
-            variant="solid"
-            color="secondary"
-            className="hidden md:inline-flex"
-            onPress={dispatchOccurrenceDrawerOpen}
-          >
-            <CalendarCheckIcon size={16} weight="bold" />
-            Log
-            <Kbd className="bg-secondary-300 dark:bg-secondary-700 hidden px-1 py-0 lg:block">
-              L
-            </Kbd>
-          </Button>
-          <Button
-            size="sm"
-            variant="solid"
-            color="secondary"
-            onPress={dispatchNoteDrawerOpen}
-            className="hidden md:inline-flex"
-          >
-            <NotePencilIcon size={16} weight="bold" />
-            Note
-            <Kbd className="bg-secondary-300 dark:bg-secondary-700 hidden px-1 py-0 lg:block">
-              N
-            </Kbd>
-          </Button>
-          <AuthModalButton />
+        <div className="flex gap-4">
+          <div className="bg-background-100/90 dark:bg-background-900 fixed right-0 bottom-0 left-0 z-50 flex w-full gap-4 border-t border-t-slate-300 p-2 px-4 md:right-4 md:bottom-4 md:left-auto md:w-auto md:border-0 md:bg-transparent md:p-0 xl:static xl:right-auto xl:bottom-auto xl:flex-row-reverse xl:border-0 xl:bg-transparent xl:p-0 dark:border-t-slate-800 dark:md:bg-transparent dark:xl:bg-transparent">
+            <Button
+              size="sm"
+              variant="solid"
+              color="secondary"
+              onPress={dispatchNoteDrawerOpen}
+              radius={screenWidth < 768 ? 'full' : 'sm'}
+              className="flex-1 max-md:h-6 max-md:gap-1 md:flex-none"
+            >
+              <NotePencilIcon
+                weight="bold"
+                size={screenWidth < 768 ? 12 : 16}
+              />
+              Note
+              <Kbd
+                className={cn(
+                  'bg-secondary-300 dark:bg-secondary-700 text-tiny px-1 py-0 md:text-sm',
+                  !hasKeyboard && 'hidden lg:block'
+                )}
+              >
+                N
+              </Kbd>
+            </Button>
+            <Button
+              size="sm"
+              variant="solid"
+              color="primary"
+              onPress={dispatchOccurrenceDrawerOpen}
+              radius={screenWidth < 768 ? 'full' : 'sm'}
+              className="flex-1 max-md:h-6 max-md:gap-1 md:flex-none"
+            >
+              <CalendarCheckIcon
+                weight="bold"
+                size={screenWidth < 768 ? 12 : 16}
+              />
+              Log
+              <Kbd
+                className={cn(
+                  'bg-primary-400 dark:bg-primary-700 text-tiny px-1 py-0 md:text-sm',
+                  !hasKeyboard && 'hidden lg:block'
+                )}
+              >
+                L
+              </Kbd>
+            </Button>
+          </div>
+          <div className="flex items-center gap-4">
+            <Button
+              as={Link}
+              size="sm"
+              variant="solid"
+              target="_blank"
+              color="secondary"
+              rel="noopener noreferrer"
+              className="hidden xl:inline-flex"
+              to="https://habitrack.featurebase.app/roadmap"
+            >
+              <ArrowSquareOutIcon size={16} weight="bold" />
+              Roadmap
+              <Kbd className="bg-secondary-300 dark:bg-secondary-700 hidden px-1 py-0 lg:block">
+                M
+              </Kbd>
+            </Button>
+            <AuthModalButton />
+          </div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Description

Make Log and Note actions more prominent and accessible on smaller screen sizes by positioning them absolutely at the bottom of the screen.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conditional keyboard hints that appear only when a physical keyboard is detected.

* **UI/UX Changes**
  * Reorganized header button layout with consolidated action area and improved spacing.
  * Simplified calendar navigation header by removing redundant action buttons.
  * Enhanced responsive design with adjusted padding for mobile viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->