### PR TITLE
feat(ui): add background on hover to habit rows

### DIFF
--- a/src/components/habit/HabitsTable.tsx
+++ b/src/components/habit/HabitsTable.tsx
@@ -136,9 +136,10 @@ const HabitsTable = () => {
             return (
               <TableRow
                 key={habit.id}
+                className="hover:bg-content2"
                 aria-labelledby={`habit-name-${habit.id}`}
               >
-                <TableCell className="w-10">
+                <TableCell className="w-10 rounded-l-md">
                   <HabitIcon habit={habit} />
                 </TableCell>
                 <TableCell>
@@ -169,7 +170,7 @@ const HabitsTable = () => {
                 >
                   <HabitTotalEntries id={habit.id} />
                 </TableCell>
-                <TableCell aria-label="Actions">
+                <TableCell aria-label="Actions" className="rounded-r-md">
                   <div
                     role="group"
                     className="flex justify-end gap-2"


### PR DESCRIPTION
## Description

Habit rows have distinct background color on hover.

@coderabbitai ignore 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I've tested my changes locally
- [ ] I've updated documentation if needed
