### PR TITLE
build(vite): avoid circular chunks, add more splits, use rollbar server token

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,7 +70,7 @@ export default defineConfig(({ mode }) => {
               return 'heroui';
             }
 
-            if (id.includes('motion')) {
+            if (id.includes('framer-motion') || id.includes('motion-dom')) {
               return 'framer-motion';
             }
 
@@ -87,9 +87,6 @@ export default defineConfig(({ mode }) => {
       SUPABASE_URL: JSON.stringify(env.SUPABASE_URL),
       ROLLBAR_CLIENT_ACCESS_TOKEN: JSON.stringify(
         env.ROLLBAR_CLIENT_ACCESS_TOKEN
-      ),
-      ROLLBAR_SERVER_ACCESS_TOKEN: JSON.stringify(
-        env.ROLLBAR_SERVER_ACCESS_TOKEN
       ),
     },
     plugins: [


### PR DESCRIPTION
## Description

Avoid warnings when building for production (for too large manual chunks and circular ones) and use Rollbar's post server token as its Vite plugin expects it instead of a client token.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [x] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized application bundle loading through improved code chunking configuration.
  * Updated error monitoring configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->