### PR TITLE
feat(profile): add schema and auth hook

### DIFF
--- a/src/components/calendar/CalendarNavigation.tsx
+++ b/src/components/calendar/CalendarNavigation.tsx
@@ -60,7 +60,7 @@ const CalendarNavigation = ({ focusedDate }: MonthCalendarNavigationProps) => {
     new Set([])
   );
   const weeks = React.useMemo(() => {
-    return getWeeksOfYear(focusedDate.year, firstDayOfWeek);
+    return getWeeksOfYear(focusedDate.year, firstDayOfWeek || 'mon');
   }, [focusedDate.year, firstDayOfWeek]);
 
   const calendarMode = React.useMemo(() => {

--- a/src/components/note/NoteDrawer.tsx
+++ b/src/components/note/NoteDrawer.tsx
@@ -260,8 +260,8 @@ const NoteDrawer = () => {
             />
           </Button>
         </DrawerHeader>
-        <Form onSubmit={submitNote}>
-          <DrawerBody className="w-full space-y-4">
+        <Form onSubmit={submitNote} className="max-h-[calc(100%-64px)]">
+          <DrawerBody className="w-full space-y-4 py-0.5">
             <NotePeriodPicker
               endRange={getEndRangeDate()}
               isShown={isPeriodPickerShown}
@@ -270,11 +270,13 @@ const NoteDrawer = () => {
             <Textarea
               autoFocus
               isRequired
+              minRows={5}
               name="content"
               value={content}
               variant="faded"
               disableAutosize
               label="Your note"
+              maxRows={Infinity}
               labelPlacement="outside"
               onChange={changeContent}
               disabled={isSaving || isRemoving}
@@ -283,9 +285,10 @@ const NoteDrawer = () => {
               placeholder={`Start typing your note about this ${periodKind}...`}
               errorMessage={`Empty notes are not allowed. ${existingNote ? 'If you want to empty an existing note, please remove it instead.' : ''}`}
               classNames={{
+                base: 'max-h-full',
                 label: 'after:hidden',
                 input: cn(
-                  'resize-y min-h-25 field-sizing-content max-h-96',
+                  'resize-y min-h-10 field-sizing-content max-h-full',
                   !isDesktop && 'text-base'
                 ),
               }}
@@ -302,7 +305,7 @@ const NoteDrawer = () => {
               }}
             />
           </DrawerBody>
-          <DrawerFooter className="self-end">
+          <DrawerFooter className="self-end pt-0">
             {!!existingNote && (
               <Button
                 color="danger"

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { default as useAuthSearchParams } from './use-auth-search-params';
 export { default as useCurrentTime } from './use-current-time';
+export { default as useDefaultFirstDayOfWeek } from './use-default-first-day-of-week';
 export { default as useFileField } from './use-file-field';
 export { default as useFirstDayOfWeek } from './use-first-day-of-week';
 export { default as useHasKeyboard } from './use-has-keyboard';

--- a/src/hooks/use-default-first-day-of-week.ts
+++ b/src/hooks/use-default-first-day-of-week.ts
@@ -1,0 +1,20 @@
+import { useLocale, useCalendar, useCalendarGrid } from 'react-aria';
+import { useCalendarState } from 'react-stately';
+
+import { createCalendar } from '@utils';
+
+const useDefaultFirstDayOfWeek = () => {
+  const { locale } = useLocale();
+  const calendarState = useCalendarState({
+    createCalendar,
+    locale,
+  });
+  useCalendar({}, calendarState);
+  const {
+    weekDays: [firstDayOfWeek],
+  } = useCalendarGrid({}, calendarState);
+
+  return firstDayOfWeek;
+};
+
+export default useDefaultFirstDayOfWeek;

--- a/src/hooks/use-first-day-of-week.ts
+++ b/src/hooks/use-first-day-of-week.ts
@@ -2,6 +2,7 @@ import { useUser } from '@stores';
 
 const firstDaysOfWeek = ['sun', 'mon'] as const;
 
+// TODO: remove and use the corresponding value from to be integrated profile store
 const useFirstDayOfWeek = () => {
   const { user } = useUser();
   const userFirstDayOfWeek = user?.userMetadata.firstDayOfWeek;
@@ -10,13 +11,14 @@ const useFirstDayOfWeek = () => {
     userFirstDayOfWeek >= 0 &&
     userFirstDayOfWeek < 2
       ? userFirstDayOfWeek
-      : 0;
+      : null;
 
-  const firstDayOfWeek = firstDaysOfWeek[firstDayOfWeekIndex];
+  const firstDayOfWeek = firstDayOfWeekIndex
+    ? firstDaysOfWeek[firstDayOfWeekIndex]
+    : undefined;
 
   return {
     firstDayOfWeek,
-    firstDayOfWeekIndex,
   };
 };
 

--- a/src/models/profile.model.ts
+++ b/src/models/profile.model.ts
@@ -1,0 +1,7 @@
+import { type CamelCasedPropertiesDeep } from 'type-fest';
+
+import { type Tables, type TablesInsert } from '@db-types';
+
+export type Profile = CamelCasedPropertiesDeep<Tables<'profiles'>>;
+
+export type ProfilesInsert = CamelCasedPropertiesDeep<TablesInsert<'profiles'>>;

--- a/src/pages/MonthCalendarPage.tsx
+++ b/src/pages/MonthCalendarPage.tsx
@@ -1,4 +1,3 @@
-import { GregorianCalendar } from '@internationalized/date';
 import capitalize from 'lodash.capitalize';
 import React from 'react';
 import { useLocale, useCalendar } from 'react-aria';
@@ -6,16 +5,7 @@ import { useCalendarState } from 'react-stately';
 
 import { MonthCalendar } from '@components';
 import { useFirstDayOfWeek } from '@hooks';
-
-const createCalendar = (identifier: string) => {
-  switch (identifier) {
-    case 'gregory':
-      return new GregorianCalendar();
-
-    default:
-      throw new Error(`Unsupported calendar ${identifier}`);
-  }
-};
+import { createCalendar } from '@utils';
 
 const MonthCalendarPage = () => {
   const { locale } = useLocale();

--- a/src/utils/create-calendar.ts
+++ b/src/utils/create-calendar.ts
@@ -1,0 +1,13 @@
+import { GregorianCalendar } from '@internationalized/date';
+
+const createCalendar = (identifier: string) => {
+  switch (identifier) {
+    case 'gregory':
+      return new GregorianCalendar();
+
+    default:
+      throw new Error(`Unsupported calendar ${identifier}`);
+  }
+};
+
+export default createCalendar;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './camelcase';
+export { default as createCalendar } from './create-calendar';
 export * from './date';
 export { default as getErrorMessage } from './get-error-message';
 export { default as handleAsyncAction } from './handle-async-action';

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -934,7 +934,9 @@ export type Database = {
       }
     }
     Enums: {
+      days_of_week: "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun"
       note_period_kind: "day" | "week" | "month"
+      user_plans: "free" | "pro"
       metric_type:
         | "number"
         | "duration"
@@ -1184,6 +1186,36 @@ export type Database = {
           time_zone?: string
           updated_at?: string | null
           user_id?: string
+        }
+      }
+      profiles: {
+        Relationships: []
+        Insert: {
+          created_at?: string
+          email: string
+          first_day_of_week?: Database["public"]["Enums"]["days_of_week"]
+          id: string
+          name?: string | null
+          plan?: Database["public"]["Enums"]["user_plans"]
+          updated_at?: string | null
+        }
+        Row: {
+          created_at: string
+          email: string
+          first_day_of_week: Database["public"]["Enums"]["days_of_week"]
+          id: string
+          name: string | null
+          plan: Database["public"]["Enums"]["user_plans"]
+          updated_at: string | null
+        }
+        Update: {
+          created_at?: string
+          email?: string
+          first_day_of_week?: Database["public"]["Enums"]["days_of_week"]
+          id?: string
+          name?: string | null
+          plan?: Database["public"]["Enums"]["user_plans"]
+          updated_at?: string | null
         }
       }
       traits: {
@@ -1866,7 +1898,9 @@ export const Constants = {
   },
   public: {
     Enums: {
+      days_of_week: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
       note_period_kind: ["day", "week", "month"],
+      user_plans: ["free", "pro"],
       metric_type: [
         "number",
         "duration",

--- a/supabase/migrations/20260219173127_add_profiles_table_and_auth_hook.sql
+++ b/supabase/migrations/20260219173127_add_profiles_table_and_auth_hook.sql
@@ -1,0 +1,127 @@
+CREATE TYPE "public"."days_of_week" AS ENUM ('mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun');
+
+CREATE TYPE "public"."user_plans" AS ENUM ('free', 'pro');
+
+CREATE TABLE "public"."profiles" (
+    "id" UUID NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "plan" "public"."user_plans" NOT NULL
+    DEFAULT 'free'::"public"."user_plans", -- noqa: disable=convention.quoted_literals
+    "first_day_of_week" "public"."days_of_week" NOT NULL DEFAULT 'mon'::"public"."days_of_week",
+    "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    "updated_at" TIMESTAMP WITH TIME ZONE
+);
+
+ALTER TABLE "public"."profiles" ENABLE ROW LEVEL SECURITY;
+
+CREATE UNIQUE INDEX "profiles_email_key" ON "public"."profiles" USING "btree" ("email");
+
+CREATE UNIQUE INDEX "profiles_pkey" ON "public"."profiles" USING "btree" ("id");
+
+ALTER TABLE "public"."profiles" ADD CONSTRAINT "profiles_pkey" PRIMARY KEY USING INDEX "profiles_pkey";
+
+ALTER TABLE "public"."profiles" ADD CONSTRAINT "profiles_email_key" UNIQUE USING INDEX "profiles_email_key";
+
+ALTER TABLE "public"."profiles" ADD CONSTRAINT "profiles_id_fkey" FOREIGN KEY ("id") REFERENCES "auth"."users" (
+    "id"
+) ON DELETE CASCADE NOT VALID;
+
+ALTER TABLE "public"."profiles" VALIDATE CONSTRAINT "profiles_id_fkey";
+
+GRANT DELETE ON TABLE "public"."profiles" TO "anon";
+
+GRANT INSERT ON TABLE "public"."profiles" TO "anon";
+
+GRANT REFERENCES ON TABLE "public"."profiles" TO "anon";
+
+GRANT SELECT ON TABLE "public"."profiles" TO "anon";
+
+GRANT TRIGGER ON TABLE "public"."profiles" TO "anon";
+
+GRANT TRUNCATE ON TABLE "public"."profiles" TO "anon";
+
+GRANT UPDATE ON TABLE "public"."profiles" TO "anon";
+
+GRANT DELETE ON TABLE "public"."profiles" TO "authenticated";
+
+GRANT INSERT ON TABLE "public"."profiles" TO "authenticated";
+
+GRANT REFERENCES ON TABLE "public"."profiles" TO "authenticated";
+
+GRANT SELECT ON TABLE "public"."profiles" TO "authenticated";
+
+GRANT TRIGGER ON TABLE "public"."profiles" TO "authenticated";
+
+GRANT TRUNCATE ON TABLE "public"."profiles" TO "authenticated";
+
+GRANT UPDATE ON TABLE "public"."profiles" TO "authenticated";
+
+GRANT DELETE ON TABLE "public"."profiles" TO "service_role";
+
+GRANT INSERT ON TABLE "public"."profiles" TO "service_role";
+
+GRANT REFERENCES ON TABLE "public"."profiles" TO "service_role";
+
+GRANT SELECT ON TABLE "public"."profiles" TO "service_role";
+
+GRANT TRIGGER ON TABLE "public"."profiles" TO "service_role";
+
+GRANT TRUNCATE ON TABLE "public"."profiles" TO "service_role";
+
+GRANT UPDATE ON TABLE "public"."profiles" TO "service_role";
+
+CREATE POLICY "Enable delete for users based on id"
+ON "public"."profiles"
+AS PERMISSIVE
+FOR DELETE
+TO "public"
+USING (("auth"."uid"() = "id"));
+
+CREATE POLICY "Enable insert for users based on user_id"
+ON "public"."profiles"
+AS PERMISSIVE
+FOR INSERT
+TO "public"
+WITH CHECK (("auth"."uid"() = "id"));
+
+CREATE POLICY "Enable read access for users based on user_id"
+ON "public"."profiles"
+AS PERMISSIVE
+FOR SELECT
+TO "public"
+USING (((SELECT "auth"."uid"() AS "uid") = "id"));
+
+CREATE POLICY "Enable update for users based on user_id"
+ON "public"."profiles"
+AS PERMISSIVE
+FOR UPDATE
+TO "public"
+USING (("auth"."uid"() = "id"));
+
+CREATE TRIGGER "set_updated_at" BEFORE UPDATE ON "public"."profiles"
+FOR EACH ROW EXECUTE FUNCTION "public"."update_updated_at_column"();
+
+CREATE OR REPLACE FUNCTION "public"."create_profile"() -- noqa
+RETURNS TRIGGER
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET search_path TO "public"
+AS $function$
+BEGIN
+    INSERT INTO "public"."profiles" (id, email, name, first_day_of_week)
+    VALUES (new.id, new.email, new.raw_user_meta_data->>'name', COALESCE((new.raw_user_meta_data->>'first_day_of_week')::days_of_week, 'mon'));
+    RETURN new;
+END;
+$function$;
+
+CREATE TRIGGER on_auth_user_created AFTER INSERT ON "auth"."users"
+FOR EACH ROW EXECUTE FUNCTION "public"."create_profile"();
+
+INSERT INTO "public"."profiles" (id, email, name)
+SELECT
+    id,
+    email,
+    raw_user_meta_data->>'name'
+FROM "auth"."users"
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/schemas/01_types.sql
+++ b/supabase/schemas/01_types.sql
@@ -43,3 +43,13 @@ CREATE TYPE "public"."metric_type" AS ENUM (
 );
 
 ALTER TYPE "public"."metric_type" OWNER TO "postgres";
+
+-- Type for user subscription plans --
+CREATE TYPE "public"."user_plans" AS ENUM ('free', 'pro');
+
+ALTER TYPE "public"."user_plans" OWNER TO "postgres";
+
+-- Type for days of the week --
+CREATE TYPE "public"."days_of_week" AS ENUM ('mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun');
+
+ALTER TYPE "public"."days_of_week" OWNER TO "postgres";

--- a/supabase/schemas/02_functions.sql
+++ b/supabase/schemas/02_functions.sql
@@ -1,5 +1,19 @@
 -- Utility functions for the application
 
+-- Function to create a profile when a new user is created in the auth system --
+CREATE OR REPLACE FUNCTION "public"."create_profile"() RETURNS "trigger" -- noqa
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO "public"
+    AS $$
+BEGIN
+    INSERT INTO "public"."profiles" (id, email, name, first_day_of_week)
+    VALUES (new.id, new.email, new.raw_user_meta_data->>'name', COALESCE((new.raw_user_meta_data->>'first_day_of_week')::days_of_week, 'mon'));
+    RETURN new;
+END;
+$$;
+
+ALTER FUNCTION "public"."create_profile"() OWNER TO "postgres";
+
 -- Function to track the longest streak for a habit
 CREATE OR REPLACE FUNCTION "public"."get_longest_streak"( -- noqa
     "p_habit_id" "uuid",
@@ -160,3 +174,7 @@ GRANT ALL ON FUNCTION "public"."get_habits_stats"("p_habit_ids" "uuid"[], "p_tim
 GRANT ALL ON FUNCTION "public"."update_updated_at_column"() TO "anon";
 GRANT ALL ON FUNCTION "public"."update_updated_at_column"() TO "authenticated";
 GRANT ALL ON FUNCTION "public"."update_updated_at_column"() TO "service_role";
+
+GRANT ALL ON FUNCTION "public"."create_profile"() TO "anon";
+GRANT ALL ON FUNCTION "public"."create_profile"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."create_profile"() TO "service_role";

--- a/supabase/schemas/10_accounts.sql
+++ b/supabase/schemas/10_accounts.sql
@@ -1,0 +1,38 @@
+CREATE TABLE "public"."profiles" (
+    "id" UUID REFERENCES "auth"."users" ("id") ON DELETE CASCADE PRIMARY KEY,
+    "email" TEXT UNIQUE NOT NULL,
+    "name" TEXT,
+    "plan" "public"."user_plans" NOT NULL DEFAULT 'free', -- noqa: disable=convention.quoted_literals
+    "first_day_of_week" "public"."days_of_week" NOT NULL DEFAULT 'mon',
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "updated_at" TIMESTAMPTZ
+);
+
+CREATE OR REPLACE TRIGGER "set_updated_at" BEFORE UPDATE ON "public"."profiles"
+FOR EACH ROW EXECUTE FUNCTION "public"."update_updated_at_column"();
+
+GRANT ALL ON TABLE "public"."profiles" TO "anon";
+GRANT ALL ON TABLE "public"."profiles" TO "authenticated";
+GRANT ALL ON TABLE "public"."profiles" TO "service_role";
+
+ALTER TABLE "public"."profiles" OWNER TO "postgres";
+
+ALTER TABLE "public"."profiles" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Enable read access for users based on user_id" ON "public"."profiles"
+FOR SELECT USING (((SELECT "auth"."uid"() AS "uid") = "id"));
+
+CREATE POLICY "Enable insert for users based on user_id" ON "public"."profiles" FOR INSERT WITH CHECK (
+    ("auth"."uid"() = "id")
+);
+
+CREATE POLICY "Enable update for users based on user_id" ON "public"."profiles" FOR UPDATE USING (
+    ("auth"."uid"() = "id")
+);
+
+CREATE POLICY "Enable delete for users based on id" ON "public"."profiles" FOR DELETE USING (
+    ("auth"."uid"() = "id")
+);
+
+CREATE TRIGGER "on_auth_user_created" AFTER INSERT ON "auth"."users"
+FOR EACH ROW EXECUTE FUNCTION "public"."create_profile"();


### PR DESCRIPTION
## Description

Add user profiles support and related utilities: create new DB enums (days_of_week, user_plans), profiles table, migration and schema SQL (including create_profile trigger/function), and update generated database types. Introduce Profile/ProfilesInsert TypeScript types and export a new useDefaultFirstDayOfWeek hook that derives the locale default using react-aria/react-stately. Add a createCalendar utility and export it from utils; switch MonthCalendarPage to use the utility. Tweak useFirstDayOfWeek to return undefined for unset values and add a TODO. Small UI/layout fixes in NoteDrawer (textarea sizing, padding, max heights) and update utils index to re-export createCalendar.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User profiles now supported with configurable settings (first day of week, plan type)
  * Automatic profile creation upon user signup
  * Calendar now respects the user's preferred first day of week setting

* **Bug Fixes**
  * Calendar navigation properly defaults first day of week when undefined

* **UI Improvements**
  * Enhanced NoteDrawer layout and sizing for better content presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->