### PR TITLE
feat: update kbd ui and add enter modifier key

### DIFF
--- a/src/components/account/AuthModalButton.tsx
+++ b/src/components/account/AuthModalButton.tsx
@@ -181,8 +181,8 @@ const AuthModalButton = () => {
         >
           <Kbd
             className={cn(
-              'bg-primary-400 dark:bg-primary-700 text-tiny px-1 py-0 md:text-sm',
-              !hasKeyboard && 'hidden lg:block'
+              'bg-primary-400 dark:bg-primary-700 text-tiny hidden px-1 py-0 md:text-sm',
+              hasKeyboard && 'block'
             )}
           >
             I

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -130,8 +130,8 @@ const Header = () => {
               Note
               <Kbd
                 className={cn(
-                  'bg-secondary-300 dark:bg-secondary-700 text-tiny px-1 py-0 md:text-sm',
-                  !hasKeyboard && 'hidden lg:block'
+                  'bg-secondary-300 dark:bg-secondary-700 text-tiny hidden px-1 py-0 md:text-sm',
+                  hasKeyboard && 'block'
                 )}
               >
                 N
@@ -152,8 +152,8 @@ const Header = () => {
               Log
               <Kbd
                 className={cn(
-                  'bg-primary-400 dark:bg-primary-700 text-tiny px-1 py-0 md:text-sm',
-                  !hasKeyboard && 'hidden lg:block'
+                  'bg-primary-400 dark:bg-primary-700 text-tiny hidden px-1 py-0 md:text-sm',
+                  hasKeyboard && 'block'
                 )}
               >
                 L
@@ -173,7 +173,12 @@ const Header = () => {
             >
               <ArrowSquareOutIcon size={16} weight="bold" />
               Roadmap
-              <Kbd className="bg-secondary-300 dark:bg-secondary-700 hidden px-1 py-0 lg:block">
+              <Kbd
+                className={cn(
+                  'bg-secondary-300 dark:bg-secondary-700 hidden px-1 py-0',
+                  hasKeyboard && 'block'
+                )}
+              >
                 M
               </Kbd>
             </Button>

--- a/src/components/note/NoteDrawer.tsx
+++ b/src/components/note/NoteDrawer.tsx
@@ -49,7 +49,7 @@ const NoteDrawer = () => {
   const [isPeriodPickerShown, setIsPeriodPickerShown] = React.useState(false);
   const [isSaving, setIsSaving] = React.useState(false);
   const [isRemoving, setIsRemoving] = React.useState(false);
-  const { mod } = useModifierKeys();
+  const { enter, mod } = useModifierKeys();
   const hasKeyboard = useHasKeyboard();
   const { isOpen, periodDate, periodKind } = useNoteDrawerState();
   const { closeNoteDrawer } = useNoteDrawerActions();
@@ -304,7 +304,7 @@ const NoteDrawer = () => {
               }}
             />
           </DrawerBody>
-          <DrawerFooter className="self-end pt-0">
+          <DrawerFooter className="w-full self-end pt-0 sm:w-auto">
             {!!existingNote && (
               <Button
                 color="danger"
@@ -319,6 +319,7 @@ const NoteDrawer = () => {
               type="submit"
               color="primary"
               isLoading={isSaving}
+              fullWidth={isMobile && !existingNote}
               isDisabled={
                 !user ||
                 isRemoving ||
@@ -326,17 +327,14 @@ const NoteDrawer = () => {
                 existingNote?.content === content
               }
             >
-              {hasKeyboard && (
-                <>
-                  <Kbd className="[&_span]:text-default-500 dark:[&_span]:text-default-700">
-                    {mod}
-                  </Kbd>
-                  <Kbd
-                    keys={['enter']}
-                    className="[&_abbr]:text-default-500 dark:[&_abbr]:text-default-700"
-                  />
-                </>
-              )}
+              <Kbd
+                className={cn(
+                  'bg-primary-400 dark:bg-primary-700 text-tiny hidden px-1.5 py-0.5 md:text-sm',
+                  hasKeyboard && 'block'
+                )}
+              >
+                {mod} {enter}
+              </Kbd>
               {existingNote ? 'Save' : 'Add'}
             </Button>
           </DrawerFooter>

--- a/src/hooks/use-modifier-keys.ts
+++ b/src/hooks/use-modifier-keys.ts
@@ -30,6 +30,7 @@ const useModifierKeys = () => {
   return {
     alt: isMac ? '⌥' : 'Alt',
     ctrl: isMac ? '⌃' : 'Ctrl',
+    enter: '⏎',
     mod: isMac ? '⌘' : 'Ctrl',
     shift: '⇧',
   };


### PR DESCRIPTION
## Description

Add an `enter` symbol to useModifierKeys and update keyboard shortcut visuals across components. Kbd elements in AuthModalButton, Header and NoteDrawer now use a hidden-by-default + hasKeyboard -> block pattern for consistent responsive behavior. NoteDrawer layout adjusted: footer width/behavior improved and primary button uses fullWidth on mobile when adding a new note. The NoteDrawer save button now shows combined modifier + enter keys (e.g. ⌘ ⏎) to clarify the keyboard shortcut.

@coderabbitai ignore 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed
