### PR TITLE
feat(habit): make habit name editable inline on details page

### DIFF
--- a/src/components/habit/HabitDetails.tsx
+++ b/src/components/habit/HabitDetails.tsx
@@ -1,13 +1,37 @@
+import { Input, Button } from '@heroui/react';
+import { XIcon, CheckIcon, PencilSimpleIcon } from '@phosphor-icons/react';
+import { useState } from 'react';
+
 import { TraitChip } from '@components';
 import type { Habit } from '@models';
 import { StorageBuckets } from '@models';
 import { getPublicUrl } from '@services';
+import { useHabitActions } from '@stores';
 
 type HabitDetailsProps = {
   habit: Habit;
 };
 
 const HabitDetails = ({ habit }: HabitDetailsProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [name, setName] = useState(habit.name);
+  const { updateHabit } = useHabitActions();
+
+  const handleSave = async () => {
+    const trimmed = name.trim();
+
+    if (trimmed && trimmed !== habit.name) {
+      await updateHabit(habit.id, { name: trimmed });
+    }
+
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setName(habit.name);
+    setIsEditing(false);
+  };
+
   return (
     <div className="flex flex-col gap-10 py-8">
       <div className="flex gap-4">
@@ -23,7 +47,65 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
         </div>
         <div className="space-y-2">
           <div className="flex items-center gap-3">
-            <h1 className="text-2xl font-bold">{habit.name}</h1>
+            {isEditing ? (
+              <Input
+                autoFocus
+                size="sm"
+                value={name}
+                onValueChange={setName}
+                classNames={{
+                  innerWrapper: 'py-2',
+                  input: 'text-2xl font-bold',
+                  inputWrapper: 'h-auto',
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSave();
+                  }
+
+                  if (e.key === 'Escape') {
+                    handleCancel();
+                  }
+                }}
+                endContent={
+                  <div className="flex gap-1">
+                    <Button
+                      size="sm"
+                      isIconOnly
+                      variant="light"
+                      onPress={handleSave}
+                      isDisabled={!name.trim()}
+                    >
+                      <CheckIcon className="size-4" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      isIconOnly
+                      variant="light"
+                      onPress={handleCancel}
+                    >
+                      <XIcon className="size-4" />
+                    </Button>
+                  </div>
+                }
+              />
+            ) : (
+              <div className="group flex items-center gap-2">
+                <h1 className="text-2xl font-bold">{habit.name}</h1>
+                <Button
+                  size="sm"
+                  isIconOnly
+                  variant="light"
+                  className="opacity-0 transition-opacity group-hover:opacity-100"
+                  onPress={() => {
+                    setName(habit.name);
+                    setIsEditing(true);
+                  }}
+                >
+                  <PencilSimpleIcon className="size-4" />
+                </Button>
+              </div>
+            )}
             {habit.trait && <TraitChip trait={habit.trait} />}
           </div>
           {habit.description && <p>{habit.description}</p>}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -46,7 +46,7 @@ const Header = () => {
       height="3rem"
       maxWidth="full"
       isBlurred={false}
-      className="bg-background-100 dark:dark:bg-background-900 [&>header]:static [&>header]:lg:px-16"
+      className="bg-background-100 dark:bg-background-900 [&>header]:static [&>header]:lg:px-16"
     >
       <NavbarContent justify="start" className="flex items-center gap-2">
         <NavbarItem>

--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -9,11 +9,13 @@ export default new Rollbar({
     client: {
       javascript: {
         code_version: VERCEL_GIT_COMMIT_SHA || '0.1.0',
+        guess_uncaught_frames: true,
         source_map_enabled: true,
       },
     },
   },
   replay: {
     enabled: true,
+    inlineImages: true,
   },
 });


### PR DESCRIPTION
## Description

Make habit name editable inline on details page.

@coderabbitai ignore 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Habit names now support inline editing with a pencil icon; use Enter to save changes or Escape to cancel.

* **Improvements**
  * Enhanced error tracking and replay capabilities to improve system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->