### PR TITLE
feat(habit): add motivation and limits to name and description columns

### DIFF
--- a/src/components/habit/AddHabitDialogButton.tsx
+++ b/src/components/habit/AddHabitDialogButton.tsx
@@ -3,7 +3,6 @@ import {
   Modal,
   Button,
   Select,
-  Textarea,
   ModalBody,
   SelectItem,
   ModalFooter,
@@ -155,17 +154,29 @@ const AddHabitDialogButton = () => {
               size="sm"
               value={name}
               label="Name"
+              maxLength={50}
               variant="faded"
               onChange={handleNameChange}
               placeholder="Enter habit name"
+              endContent={
+                <span className="text-foreground-400 text-tiny whitespace-nowrap">
+                  {name.length}/50
+                </span>
+              }
             />
-            <Textarea
+            <Input
               size="sm"
               variant="faded"
+              maxLength={100}
               value={description}
               label="Description"
               onChange={handleDescriptionChange}
               placeholder="Enter habit description (optional)"
+              endContent={
+                <span className="text-foreground-400 text-tiny whitespace-nowrap">
+                  {description.length}/100
+                </span>
+              }
             />
             <Select
               required

--- a/src/components/habit/HabitDetails.tsx
+++ b/src/components/habit/HabitDetails.tsx
@@ -1,4 +1,4 @@
-import { Input, Button } from '@heroui/react';
+import { cn, Input, Button } from '@heroui/react';
 import { XIcon, CheckIcon, PencilSimpleIcon } from '@phosphor-icons/react';
 import React from 'react';
 
@@ -13,23 +13,40 @@ type HabitDetailsProps = {
 };
 
 const HabitDetails = ({ habit }: HabitDetailsProps) => {
-  const [isEditing, setIsEditing] = React.useState(false);
+  const [isEditingName, setIsEditingName] = React.useState(false);
   const [name, setName] = React.useState(habit.name);
+  const [isEditingDescription, setIsEditingDescription] = React.useState(false);
+  const [description, setDescription] = React.useState(habit.description || '');
   const { updateHabit } = useHabitActions();
 
-  const handleSave = async () => {
+  const handleNameSave = async () => {
     const trimmed = name.trim();
 
     if (trimmed && trimmed !== habit.name) {
       await updateHabit(habit.id, { name: trimmed });
     }
 
-    setIsEditing(false);
+    setIsEditingName(false);
   };
 
-  const handleCancel = () => {
+  const handleNameCancel = () => {
     setName(habit.name);
-    setIsEditing(false);
+    setIsEditingName(false);
+  };
+
+  const handleDescriptionSave = async () => {
+    const trimmed = description.trim();
+
+    if (trimmed !== (habit.description || '')) {
+      await updateHabit(habit.id, { description: trimmed || null });
+    }
+
+    setIsEditingDescription(false);
+  };
+
+  const handleDescriptionCancel = () => {
+    setDescription(habit.description || '');
+    setIsEditingDescription(false);
   };
 
   return (
@@ -47,11 +64,12 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
         </div>
         <div className="space-y-2">
           <div className="flex items-center gap-3">
-            {isEditing ? (
+            {isEditingName ? (
               <Input
                 autoFocus
                 size="sm"
                 value={name}
+                maxLength={50}
                 onValueChange={setName}
                 classNames={{
                   innerWrapper: 'py-2',
@@ -60,20 +78,23 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                 }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
-                    handleSave();
+                    handleNameSave();
                   }
 
                   if (e.key === 'Escape') {
-                    handleCancel();
+                    handleNameCancel();
                   }
                 }}
                 endContent={
-                  <div className="flex gap-1">
+                  <div className="flex items-center gap-1">
+                    <span className="text-foreground-400 text-tiny whitespace-nowrap">
+                      {name.length}/50
+                    </span>
                     <Button
                       size="sm"
                       isIconOnly
                       variant="light"
-                      onPress={handleSave}
+                      onPress={handleNameSave}
                       isDisabled={!name.trim()}
                     >
                       <CheckIcon className="size-4" />
@@ -82,7 +103,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                       size="sm"
                       isIconOnly
                       variant="light"
-                      onPress={handleCancel}
+                      onPress={handleNameCancel}
                     >
                       <XIcon className="size-4" />
                     </Button>
@@ -99,7 +120,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                   className="opacity-0 transition-opacity group-hover:opacity-100"
                   onPress={() => {
                     setName(habit.name);
-                    setIsEditing(true);
+                    setIsEditingName(true);
                   }}
                 >
                   <PencilSimpleIcon className="size-4" />
@@ -108,7 +129,68 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
             )}
             {habit.trait && <TraitChip trait={habit.trait} />}
           </div>
-          {habit.description && <p>{habit.description}</p>}
+          {isEditingDescription ? (
+            <Input
+              autoFocus
+              size="sm"
+              maxLength={100}
+              value={description}
+              placeholder="No description"
+              onValueChange={setDescription}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  handleDescriptionSave();
+                }
+
+                if (e.key === 'Escape') {
+                  handleDescriptionCancel();
+                }
+              }}
+              endContent={
+                <div className="flex items-center gap-1">
+                  <span className="text-foreground-400 text-tiny whitespace-nowrap">
+                    {description.length}/100
+                  </span>
+                  <Button
+                    size="sm"
+                    isIconOnly
+                    variant="light"
+                    onPress={handleDescriptionSave}
+                  >
+                    <CheckIcon className="size-4" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    isIconOnly
+                    variant="light"
+                    onPress={handleDescriptionCancel}
+                  >
+                    <XIcon className="size-4" />
+                  </Button>
+                </div>
+              }
+            />
+          ) : (
+            <div className="group flex items-center gap-2">
+              <p
+                className={cn(!habit.description && 'text-default-500 italic')}
+              >
+                {habit.description || 'No description'}
+              </p>
+              <Button
+                size="sm"
+                isIconOnly
+                variant="light"
+                className="opacity-0 transition-opacity group-hover:opacity-100"
+                onPress={() => {
+                  setDescription(habit.description || '');
+                  setIsEditingDescription(true);
+                }}
+              >
+                <PencilSimpleIcon className="size-4" />
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/supabase/migrations/20260226162055_add_habit_name_description_limits_and_motivation_column.sql
+++ b/supabase/migrations/20260226162055_add_habit_name_description_limits_and_motivation_column.sql
@@ -1,0 +1,19 @@
+ALTER TABLE "public"."habits" DROP CONSTRAINT "habits_name_check";
+
+ALTER TABLE "public"."habits" ADD COLUMN "motivation" CHARACTER VARYING(2000);
+
+ALTER TABLE "public"."habits" ALTER COLUMN "description" SET DATA TYPE CHARACTER VARYING(
+    100
+) USING "description"::CHARACTER VARYING(100);
+
+ALTER TABLE "public"."habits" ALTER COLUMN "name"
+SET DEFAULT 'Untitled'::CHARACTER VARYING; -- noqa: disable=convention.quoted_literals
+
+ALTER TABLE "public"."habits" ALTER COLUMN "name" SET DATA TYPE CHARACTER VARYING(50) USING "name"::CHARACTER VARYING(
+    50
+);
+
+ALTER TABLE "public"."habits" ADD CONSTRAINT "habits_name_check"
+CHECK ((("name")::TEXT <> ''::TEXT)) NOT VALID;
+
+ALTER TABLE "public"."habits" VALIDATE CONSTRAINT "habits_name_check";

--- a/supabase/schemas/05_habits.sql
+++ b/supabase/schemas/05_habits.sql
@@ -5,8 +5,9 @@ CREATE TABLE IF NOT EXISTS "public"."habits" (
     "created_at" TIMESTAMP WITH TIME ZONE DEFAULT "now"() NOT NULL,
     "updated_at" TIMESTAMP WITH TIME ZONE,
     "user_id" UUID NOT NULL,
-    "name" TEXT NOT NULL CHECK ("name" <> ''), -- noqa: CV10
-    "description" TEXT,
+    "name" VARCHAR(50) NOT NULL DEFAULT 'Untitled' CHECK ("name" <> ''), -- noqa: CV10
+    "description" VARCHAR(100),
+    "motivation" VARCHAR(2000),
     "icon_path" TEXT,
     "id" UUID DEFAULT "gen_random_uuid"() NOT NULL,
     "trait_id" UUID


### PR DESCRIPTION
## Description

Enforce length limits and improve habit editing UX, and add a motivation column to the DB.

Client: set maxLength for habit name (50) and description (100), replace the add-habit Textarea with Input, and add inline character counters. HabitDetails now has separate editing states for name and description, keyboard shortcuts (Enter/Escape), save/cancel buttons, and improved styling; also imports cn for conditional classNames.

DB: new migration adds a "motivation" VARCHAR(2000), constrains description to VARCHAR(100) and name to VARCHAR(50) with a default 'Untitled' and revalidates the non-empty name check. Schema file updated to match the migration.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added motivation field to habit creation and editing.
  * Introduced character counters and input limits for habit details (50 characters for names, 100 for descriptions).

* **Improvements**
  * Changed description input to single-line format for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->