### PR TITLE
feat(habit): add inline-editable motivation field to details page

### DIFF
--- a/src/components/habit/HabitDetails.tsx
+++ b/src/components/habit/HabitDetails.tsx
@@ -1,4 +1,4 @@
-import { cn, Input, Button } from '@heroui/react';
+import { cn, Input, Button, Textarea } from '@heroui/react';
 import { XIcon, CheckIcon, PencilSimpleIcon } from '@phosphor-icons/react';
 import React from 'react';
 
@@ -17,36 +17,49 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
   const [name, setName] = React.useState(habit.name);
   const [isEditingDescription, setIsEditingDescription] = React.useState(false);
   const [description, setDescription] = React.useState(habit.description || '');
+  const [isEditingMotivation, setIsEditingMotivation] = React.useState(false);
+  const [motivation, setMotivation] = React.useState(habit.motivation || '');
   const { updateHabit } = useHabitActions();
 
-  const handleNameSave = async () => {
-    const trimmed = name.trim();
+  const saveHabit = async () => {
+    const trimmedName = name.trim();
+    const trimmedDescription = description.trim();
+    const trimmedMotivation = motivation.trim();
 
-    if (trimmed && trimmed !== habit.name) {
-      await updateHabit(habit.id, { name: trimmed });
+    if (trimmedName && trimmedName !== habit.name) {
+      await updateHabit(habit.id, { name: trimmedName });
+    }
+
+    if (trimmedDescription !== (habit.description || '')) {
+      await updateHabit(habit.id, { description: trimmedDescription || null });
+    }
+
+    if (trimmedMotivation !== (habit.motivation || '')) {
+      await updateHabit(habit.id, { motivation: trimmedMotivation || null });
     }
 
     setIsEditingName(false);
+    setIsEditingDescription(false);
+    setIsEditingMotivation(false);
   };
 
-  const handleNameCancel = () => {
+  const cancelEditing = () => {
     setName(habit.name);
+    setDescription(habit.description || '');
+    setMotivation(habit.motivation || '');
     setIsEditingName(false);
+    setIsEditingDescription(false);
+    setIsEditingMotivation(false);
   };
 
-  const handleDescriptionSave = async () => {
-    const trimmed = description.trim();
-
-    if (trimmed !== (habit.description || '')) {
-      await updateHabit(habit.id, { description: trimmed || null });
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      saveHabit();
     }
 
-    setIsEditingDescription(false);
-  };
-
-  const handleDescriptionCancel = () => {
-    setDescription(habit.description || '');
-    setIsEditingDescription(false);
+    if (e.key === 'Escape') {
+      cancelEditing();
+    }
   };
 
   return (
@@ -71,19 +84,10 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                 value={name}
                 maxLength={50}
                 onValueChange={setName}
+                onKeyDown={handleKeyDown}
                 classNames={{
                   innerWrapper: 'py-2',
-                  input: 'text-2xl font-bold',
                   inputWrapper: 'h-auto',
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    handleNameSave();
-                  }
-
-                  if (e.key === 'Escape') {
-                    handleNameCancel();
-                  }
                 }}
                 endContent={
                   <div className="flex items-center gap-1">
@@ -94,7 +98,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                       size="sm"
                       isIconOnly
                       variant="light"
-                      onPress={handleNameSave}
+                      onPress={saveHabit}
                       isDisabled={!name.trim()}
                     >
                       <CheckIcon className="size-4" />
@@ -103,7 +107,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                       size="sm"
                       isIconOnly
                       variant="light"
-                      onPress={handleNameCancel}
+                      onPress={cancelEditing}
                     >
                       <XIcon className="size-4" />
                     </Button>
@@ -117,11 +121,16 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                   size="sm"
                   isIconOnly
                   variant="light"
-                  className="opacity-0 transition-opacity group-hover:opacity-100"
                   onPress={() => {
                     setName(habit.name);
                     setIsEditingName(true);
                   }}
+                  className={cn(
+                    'opacity-0 transition-opacity',
+                    !isEditingDescription &&
+                      !isEditingMotivation &&
+                      'group-hover:opacity-100'
+                  )}
                 >
                   <PencilSimpleIcon className="size-4" />
                 </Button>
@@ -135,16 +144,12 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
               size="sm"
               maxLength={100}
               value={description}
+              onKeyDown={handleKeyDown}
               placeholder="No description"
               onValueChange={setDescription}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  handleDescriptionSave();
-                }
-
-                if (e.key === 'Escape') {
-                  handleDescriptionCancel();
-                }
+              classNames={{
+                innerWrapper: 'py-2',
+                inputWrapper: 'h-auto',
               }}
               endContent={
                 <div className="flex items-center gap-1">
@@ -155,7 +160,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                     size="sm"
                     isIconOnly
                     variant="light"
-                    onPress={handleDescriptionSave}
+                    onPress={saveHabit}
                   >
                     <CheckIcon className="size-4" />
                   </Button>
@@ -163,7 +168,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                     size="sm"
                     isIconOnly
                     variant="light"
-                    onPress={handleDescriptionCancel}
+                    onPress={cancelEditing}
                   >
                     <XIcon className="size-4" />
                   </Button>
@@ -181,11 +186,16 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                 size="sm"
                 isIconOnly
                 variant="light"
-                className="opacity-0 transition-opacity group-hover:opacity-100"
                 onPress={() => {
                   setDescription(habit.description || '');
                   setIsEditingDescription(true);
                 }}
+                className={cn(
+                  'opacity-0 transition-opacity',
+                  !isEditingDescription &&
+                    !isEditingMotivation &&
+                    'group-hover:opacity-100'
+                )}
               >
                 <PencilSimpleIcon className="size-4" />
               </Button>
@@ -193,6 +203,64 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
           )}
         </div>
       </div>
+      {isEditingMotivation ? (
+        <Textarea
+          maxLength={2000}
+          label="Motivation"
+          value={motivation}
+          onValueChange={setMotivation}
+          placeholder="Why do you want to track this habit? If you know the reasons for establishing a good habit or breaking a bad one, this is a good place to outline your goals."
+          endContent={
+            <div className="flex items-center gap-1">
+              <span className="text-foreground-400 text-tiny whitespace-nowrap">
+                {motivation.length}/200
+              </span>
+              <Button size="sm" isIconOnly variant="light" onPress={saveHabit}>
+                <CheckIcon className="size-4" />
+              </Button>
+              <Button
+                size="sm"
+                isIconOnly
+                variant="light"
+                onPress={cancelEditing}
+              >
+                <XIcon className="size-4" />
+              </Button>
+            </div>
+          }
+        />
+      ) : (
+        <div className="group">
+          <h2 className="mt-4 mb-1 text-sm font-medium">Motivation</h2>
+          <div className="flex gap-2">
+            <p
+              className={cn(
+                !habit.motivation && 'text-default-500 italic',
+                'whitespace-pre-wrap'
+              )}
+            >
+              {habit.motivation || 'No motivation set'}
+            </p>
+            <Button
+              size="sm"
+              isIconOnly
+              variant="light"
+              onPress={() => {
+                setMotivation(habit.motivation || '');
+                setIsEditingMotivation(true);
+              }}
+              className={cn(
+                'opacity-0 transition-opacity',
+                !isEditingDescription &&
+                  !isEditingMotivation &&
+                  'group-hover:opacity-100'
+              )}
+            >
+              <PencilSimpleIcon className="size-4" />
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -58,49 +58,151 @@ export type Database = {
           payload?: Json | null
         }
       }
+      custom_oauth_providers: {
+        Relationships: []
+        Insert: {
+          acceptable_client_ids?: string[]
+          attribute_mapping?: Json
+          authorization_params?: Json
+          authorization_url?: string | null
+          cached_discovery?: Json | null
+          client_id: string
+          client_secret: string
+          created_at?: string
+          discovery_cached_at?: string | null
+          discovery_url?: string | null
+          email_optional?: boolean
+          enabled?: boolean
+          id?: string
+          identifier: string
+          issuer?: string | null
+          jwks_uri?: string | null
+          name: string
+          pkce_enabled?: boolean
+          provider_type: string
+          scopes?: string[]
+          skip_nonce_check?: boolean
+          token_url?: string | null
+          updated_at?: string
+          userinfo_url?: string | null
+        }
+        Row: {
+          acceptable_client_ids: string[]
+          attribute_mapping: Json
+          authorization_params: Json
+          authorization_url: string | null
+          cached_discovery: Json | null
+          client_id: string
+          client_secret: string
+          created_at: string
+          discovery_cached_at: string | null
+          discovery_url: string | null
+          email_optional: boolean
+          enabled: boolean
+          id: string
+          identifier: string
+          issuer: string | null
+          jwks_uri: string | null
+          name: string
+          pkce_enabled: boolean
+          provider_type: string
+          scopes: string[]
+          skip_nonce_check: boolean
+          token_url: string | null
+          updated_at: string
+          userinfo_url: string | null
+        }
+        Update: {
+          acceptable_client_ids?: string[]
+          attribute_mapping?: Json
+          authorization_params?: Json
+          authorization_url?: string | null
+          cached_discovery?: Json | null
+          client_id?: string
+          client_secret?: string
+          created_at?: string
+          discovery_cached_at?: string | null
+          discovery_url?: string | null
+          email_optional?: boolean
+          enabled?: boolean
+          id?: string
+          identifier?: string
+          issuer?: string | null
+          jwks_uri?: string | null
+          name?: string
+          pkce_enabled?: boolean
+          provider_type?: string
+          scopes?: string[]
+          skip_nonce_check?: boolean
+          token_url?: string | null
+          updated_at?: string
+          userinfo_url?: string | null
+        }
+      }
       flow_state: {
         Relationships: []
         Insert: {
-          auth_code: string
+          auth_code?: string | null
           auth_code_issued_at?: string | null
           authentication_method: string
-          code_challenge: string
-          code_challenge_method: Database["auth"]["Enums"]["code_challenge_method"]
+          code_challenge?: string | null
           created_at?: string | null
+          email_optional?: boolean
           id: string
+          invite_token?: string | null
+          linking_target_id?: string | null
+          oauth_client_state_id?: string | null
           provider_access_token?: string | null
           provider_refresh_token?: string | null
           provider_type: string
+          referrer?: string | null
           updated_at?: string | null
           user_id?: string | null
+          code_challenge_method?:
+            | Database["auth"]["Enums"]["code_challenge_method"]
+            | null
         }
         Row: {
-          auth_code: string
+          auth_code: string | null
           auth_code_issued_at: string | null
           authentication_method: string
-          code_challenge: string
-          code_challenge_method: Database["auth"]["Enums"]["code_challenge_method"]
+          code_challenge: string | null
           created_at: string | null
+          email_optional: boolean
           id: string
+          invite_token: string | null
+          linking_target_id: string | null
+          oauth_client_state_id: string | null
           provider_access_token: string | null
           provider_refresh_token: string | null
           provider_type: string
+          referrer: string | null
           updated_at: string | null
           user_id: string | null
+          code_challenge_method:
+            | Database["auth"]["Enums"]["code_challenge_method"]
+            | null
         }
         Update: {
-          auth_code?: string
+          auth_code?: string | null
           auth_code_issued_at?: string | null
           authentication_method?: string
-          code_challenge?: string
-          code_challenge_method?: Database["auth"]["Enums"]["code_challenge_method"]
+          code_challenge?: string | null
           created_at?: string | null
+          email_optional?: boolean
           id?: string
+          invite_token?: string | null
+          linking_target_id?: string | null
+          oauth_client_state_id?: string | null
           provider_access_token?: string | null
           provider_refresh_token?: string | null
           provider_type?: string
+          referrer?: string | null
           updated_at?: string | null
           user_id?: string | null
+          code_challenge_method?:
+            | Database["auth"]["Enums"]["code_challenge_method"]
+            | null
         }
       }
       identities: {
@@ -413,6 +515,7 @@ export type Database = {
           logo_uri?: string | null
           redirect_uris: string
           registration_type: Database["auth"]["Enums"]["oauth_registration_type"]
+          token_endpoint_auth_method: string
           updated_at?: string
         }
         Row: {
@@ -427,6 +530,7 @@ export type Database = {
           logo_uri: string | null
           redirect_uris: string
           registration_type: Database["auth"]["Enums"]["oauth_registration_type"]
+          token_endpoint_auth_method: string
           updated_at: string
         }
         Update: {
@@ -441,6 +545,7 @@ export type Database = {
           logo_uri?: string | null
           redirect_uris?: string
           registration_type?: Database["auth"]["Enums"]["oauth_registration_type"]
+          token_endpoint_auth_method?: string
           updated_at?: string
         }
       }
@@ -1020,7 +1125,8 @@ export type Database = {
           description?: string | null
           icon_path?: string | null
           id?: string
-          name: string
+          motivation?: string | null
+          name?: string
           trait_id?: string | null
           updated_at?: string | null
           user_id: string
@@ -1039,6 +1145,7 @@ export type Database = {
           description: string | null
           icon_path: string | null
           id: string
+          motivation: string | null
           name: string
           trait_id: string | null
           updated_at: string | null
@@ -1049,6 +1156,7 @@ export type Database = {
           description?: string | null
           icon_path?: string | null
           id?: string
+          motivation?: string | null
           name?: string
           trait_id?: string | null
           updated_at?: string | null
@@ -1262,6 +1370,10 @@ export type Database = {
         Args: { bucketid: string; metadata: Json; name: string; owner: string }
         Returns: undefined
       }
+      get_common_prefix: {
+        Args: { p_delimiter: string; p_key: string; p_prefix: string }
+        Returns: string
+      }
       get_size_by_bucket: {
         Args: never
         Returns: {
@@ -1286,58 +1398,85 @@ export type Database = {
       }
       list_objects_with_delimiter: {
         Args: {
-          bucket_id: string
+          _bucket_id: string
           delimiter_param: string
           max_keys?: number
           next_token?: string
           prefix_param: string
+          sort_order?: string
           start_after?: string
         }
         Returns: {
+          created_at: string
           id: string
+          last_accessed_at: string
           metadata: Json
           name: string
           updated_at: string
         }[]
       }
-      search:
-        | {
-            Args: {
-              bucketname: string
-              levels?: number
-              limits?: number
-              offsets?: number
-              prefix: string
-            }
-            Returns: {
-              created_at: string
-              id: string
-              last_accessed_at: string
-              metadata: Json
-              name: string
-              updated_at: string
-            }[]
-          }
-        | {
-            Args: {
-              bucketname: string
-              levels?: number
-              limits?: number
-              offsets?: number
-              prefix: string
-              search?: string
-              sortcolumn?: string
-              sortorder?: string
-            }
-            Returns: {
-              created_at: string
-              id: string
-              last_accessed_at: string
-              metadata: Json
-              name: string
-              updated_at: string
-            }[]
-          }
+      search: {
+        Args: {
+          bucketname: string
+          levels?: number
+          limits?: number
+          offsets?: number
+          prefix: string
+          search?: string
+          sortcolumn?: string
+          sortorder?: string
+        }
+        Returns: {
+          created_at: string
+          id: string
+          last_accessed_at: string
+          metadata: Json
+          name: string
+          updated_at: string
+        }[]
+      }
+      search_by_timestamp: {
+        Args: {
+          p_bucket_id: string
+          p_level: number
+          p_limit: number
+          p_prefix: string
+          p_sort_column: string
+          p_sort_column_after: string
+          p_sort_order: string
+          p_start_after: string
+        }
+        Returns: {
+          created_at: string
+          id: string
+          key: string
+          last_accessed_at: string
+          metadata: Json
+          name: string
+          updated_at: string
+        }[]
+      }
+      search_v2: {
+        Args: {
+          bucket_name: string
+          levels?: number
+          limits?: number
+          prefix: string
+          sort_column?: string
+          sort_column_after?: string
+          sort_order?: string
+          start_after?: string
+        }
+        Returns: {
+          created_at: string
+          id: string
+          key: string
+          last_accessed_at: string
+          metadata: Json
+          name: string
+          updated_at: string
+        }[]
+      }
     }
     Tables: {
       buckets: {

--- a/tests/makeTestHabit.ts
+++ b/tests/makeTestHabit.ts
@@ -7,6 +7,7 @@ const makeTestHabit = (override: Partial<Habit> = {}): Habit => {
     iconPath: 'https://i.ibb.co/vvgw7bx/habitrack-logo.png',
     id: crypto.randomUUID(),
     metricDefinitions: [],
+    motivation: null,
     name: 'Test Habit',
     traitId: crypto.randomUUID(),
     updatedAt: null,


### PR DESCRIPTION
## Description

Add inline-editable motivation field to details page.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now add and edit a motivation field for each habit, providing a dedicated space to document personal reasons for tracking.
  * Improved editing experience with keyboard shortcuts: press Enter to quickly save changes or Escape to cancel across all habit editing fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->