### PR TITLE
feat(habit): improve details editing ui and metrics handling

### DIFF
--- a/src/components/habit/EditHabitDialog.tsx
+++ b/src/components/habit/EditHabitDialog.tsx
@@ -227,20 +227,6 @@ const EditHabitDialog = ({ habit, onClose }: EditHabitDialogProps) => {
               <MetricDefinitionForm
                 key={md.id}
                 metric={md}
-                onRemove={() => {
-                  setMetricDefinitions((prev) => {
-                    return prev.map((prevMd) => {
-                      if (prevMd.id === md.id) {
-                        return {
-                          ...prevMd,
-                          isToBeRemoved: true,
-                        };
-                      }
-
-                      return prevMd;
-                    });
-                  });
-                }}
                 onChange={(metricUpdates) => {
                   setMetricDefinitions((prev) => {
                     return prev.map((prevMd) => {
@@ -249,6 +235,26 @@ const EditHabitDialog = ({ habit, onClose }: EditHabitDialogProps) => {
                           ...prevMd,
                           ...metricUpdates,
                           isToBeUpdated: md.isPersisted,
+                        };
+                      }
+
+                      return prevMd;
+                    });
+                  });
+                }}
+                onRemove={() => {
+                  setMetricDefinitions((prev) => {
+                    if (!md.isPersisted) {
+                      return prev.filter((prevMd) => {
+                        return prevMd.id !== md.id;
+                      });
+                    }
+
+                    return prev.map((prevMd) => {
+                      if (prevMd.id === md.id) {
+                        return {
+                          ...prevMd,
+                          isToBeRemoved: true,
                         };
                       }
 

--- a/src/components/habit/HabitDetails.tsx
+++ b/src/components/habit/HabitDetails.tsx
@@ -21,12 +21,20 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
   const [motivation, setMotivation] = React.useState(habit.motivation || '');
   const { updateHabit } = useHabitActions();
 
+  const isEditing = React.useMemo(() => {
+    return isEditingName || isEditingDescription || isEditingMotivation;
+  }, [isEditingName, isEditingDescription, isEditingMotivation]);
+
   const saveHabit = async () => {
     const trimmedName = name.trim();
     const trimmedDescription = description.trim();
     const trimmedMotivation = motivation.trim();
 
-    if (trimmedName && trimmedName !== habit.name) {
+    if (isEditingName && !trimmedName) {
+      return;
+    }
+
+    if (trimmedName !== habit.name) {
       await updateHabit(habit.id, { name: trimmedName });
     }
 
@@ -54,7 +62,11 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
-      saveHabit();
+      if (isEditingName && !name.trim()) {
+        return;
+      }
+
+      void saveHabit();
     }
 
     if (e.key === 'Escape') {
@@ -83,6 +95,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                 size="sm"
                 value={name}
                 maxLength={50}
+                placeholder="Untitled"
                 onValueChange={setName}
                 onKeyDown={handleKeyDown}
                 classNames={{
@@ -99,6 +112,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                       isIconOnly
                       variant="light"
                       onPress={saveHabit}
+                      aria-label="Save name"
                       isDisabled={!name.trim()}
                     >
                       <CheckIcon className="size-4" />
@@ -108,6 +122,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                       isIconOnly
                       variant="light"
                       onPress={cancelEditing}
+                      aria-label="Cancel name editing"
                     >
                       <XIcon className="size-4" />
                     </Button>
@@ -121,22 +136,21 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                   size="sm"
                   isIconOnly
                   variant="light"
+                  aria-label="Edit name"
                   onPress={() => {
                     setName(habit.name);
                     setIsEditingName(true);
                   }}
                   className={cn(
-                    'opacity-0 transition-opacity',
-                    !isEditingDescription &&
-                      !isEditingMotivation &&
-                      'group-hover:opacity-100'
+                    'opacity-0 transition-opacity group-hover:opacity-100',
+                    isEditing && 'invisible'
                   )}
                 >
                   <PencilSimpleIcon className="size-4" />
                 </Button>
               </div>
             )}
-            {habit.trait && <TraitChip trait={habit.trait} />}
+            <TraitChip trait={habit.trait} />
           </div>
           {isEditingDescription ? (
             <Input
@@ -161,6 +175,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                     isIconOnly
                     variant="light"
                     onPress={saveHabit}
+                    aria-label="Save description"
                   >
                     <CheckIcon className="size-4" />
                   </Button>
@@ -169,6 +184,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                     isIconOnly
                     variant="light"
                     onPress={cancelEditing}
+                    aria-label="Cancel description editing"
                   >
                     <XIcon className="size-4" />
                   </Button>
@@ -186,15 +202,14 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                 size="sm"
                 isIconOnly
                 variant="light"
+                aria-label="Edit description"
                 onPress={() => {
                   setDescription(habit.description || '');
                   setIsEditingDescription(true);
                 }}
                 className={cn(
-                  'opacity-0 transition-opacity',
-                  !isEditingDescription &&
-                    !isEditingMotivation &&
-                    'group-hover:opacity-100'
+                  'opacity-0 transition-opacity group-hover:opacity-100',
+                  isEditing && 'invisible'
                 )}
               >
                 <PencilSimpleIcon className="size-4" />
@@ -213,9 +228,15 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
           endContent={
             <div className="flex items-center gap-1">
               <span className="text-foreground-400 text-tiny whitespace-nowrap">
-                {motivation.length}/200
+                {motivation.length}/2000
               </span>
-              <Button size="sm" isIconOnly variant="light" onPress={saveHabit}>
+              <Button
+                size="sm"
+                isIconOnly
+                variant="light"
+                onPress={saveHabit}
+                aria-label="Save motivation"
+              >
                 <CheckIcon className="size-4" />
               </Button>
               <Button
@@ -223,6 +244,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
                 isIconOnly
                 variant="light"
                 onPress={cancelEditing}
+                aria-label="Cancel motivation editing"
               >
                 <XIcon className="size-4" />
               </Button>
@@ -245,15 +267,14 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
               size="sm"
               isIconOnly
               variant="light"
+              aria-label="Edit motivation"
               onPress={() => {
                 setMotivation(habit.motivation || '');
                 setIsEditingMotivation(true);
               }}
               className={cn(
-                'opacity-0 transition-opacity',
-                !isEditingDescription &&
-                  !isEditingMotivation &&
-                  'group-hover:opacity-100'
+                'opacity-0 transition-opacity group-hover:opacity-100',
+                isEditing && 'invisible'
               )}
             >
               <PencilSimpleIcon className="size-4" />


### PR DESCRIPTION
## Description

Fix metric handlers in EditHabitDialog: swap onChange/onRemove behavior so metric form changegis update the metric (and mark isToBeUpdated for persisted items) while removal immediately deletes non-persisted metrics or marks persisted metrics as isToBeRemoved. This prevents accidental loss of newly-added metrics and correctly flags persisted ones for deletion.

Polish HabitDetails UI/UX and accessibility: add an isEditing memo to coordinate edit-state visibility, prevent saving empty names, ensure Enter handling uses saveHabit correctly, add placeholder and aria-labels for action buttons, always render the trait chip, hide edit buttons while any field is being edited, and update the motivation character cap display from 200 to 2000.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Motivation field now supports up to 2,000 characters (previously 200).
  * Enhanced editing interface with explicit Save and Cancel buttons for name, description, and motivation fields.

* **Improvements**
  * Added accessibility labels for all editing actions.
  * Improved field guidance with "Untitled" placeholder for the habit name field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->