### PR TITLE
feat(habit): allow updating icon on details page

### DIFF
--- a/src/components/habit/HabitDetails.tsx
+++ b/src/components/habit/HabitDetails.tsx
@@ -14,9 +14,9 @@ import React from 'react';
 
 import { TraitChip } from '@components';
 import type { Habit } from '@models';
-import { StorageBuckets } from '@models';
-import { getPublicUrl } from '@services';
 import { useTraits, useHabitActions } from '@stores';
+
+import HabitIcon from './HabitIcon';
 
 type HabitDetailsProps = {
   habit: Habit;
@@ -93,11 +93,7 @@ const HabitDetails = ({ habit }: HabitDetailsProps) => {
           style={{ borderColor: habit.trait?.color || '' }}
           className="border-content3 justify-self-start rounded-2xl border-3 p-4"
         >
-          <img
-            className="size-12"
-            alt={`${habit.name} icon`}
-            src={getPublicUrl(StorageBuckets.HABIT_ICONS, habit.iconPath)}
-          />
+          <HabitIcon habit={habit} />
         </div>
         <div className="space-y-2">
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Description

Re-use existing HabitIcon component to allow one-click upload of a new icon for a habit on the details page.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed
