### PR TITLE
feat: add mcp server implementation and oauth consent route and ui

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -24,3 +24,4 @@ jobs:
 
       - run: supabase link --project-ref $SUPABASE_PROJECT_ID
       - run: supabase db push
+      - run: supabase functions deploy

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,0 +1,155 @@
+# MCP Server (OAuth)
+
+Habitrack can act as a remote [MCP](https://modelcontextprotocol.io) server, letting
+MCP clients (ChatGPT, Claude, etc.) read and write a user's habits and occurrences
+**on that user's behalf and with their permission**. Authentication uses the
+Supabase OAuth 2.1 server, so no separate auth system is needed.
+
+## How it works
+
+```
+MCP client (ChatGPT / Claude)
+  │  1. GET <mcp>/.well-known/oauth-protected-resource  → discovers the Supabase auth server
+  │  2. Dynamic Client Registration + OAuth 2.1 (PKCE) against Supabase
+  ▼
+Supabase OAuth server  ── redirects to ──►  /oauth/consent  (React app, OAuthConsentPage)
+  │                                          user Allows/Denies
+  │  3. issues access + refresh JWT (carries the user's `sub`)
+  ▼
+MCP Edge Function (supabase/functions/mcp)
+  - verifies the JWT against Supabase JWKS
+  - builds a Supabase client with the user's token
+  ▼
+Postgres — existing RLS (`auth.uid() = user_id`) scopes every query to that user
+```
+
+The key property: **all data-access authorization is the existing RLS.** A
+per-user OAuth token produces a per-user Supabase client, so a client can only
+ever touch the authorizing user's rows. No new permission logic lives in the
+server.
+
+## Components in this repo
+
+| Piece                                     | Location                                                                                       |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Edge Function entry (tools, HTTP handler) | [`supabase/functions/mcp/index.ts`](../supabase/functions/mcp/index.ts)                        |
+| JWT verification + OAuth discovery        | [`supabase/functions/mcp/auth.ts`](../supabase/functions/mcp/auth.ts)                          |
+| Deno imports                              | [`supabase/functions/mcp/deno.json`](../supabase/functions/mcp/deno.json)                      |
+| Function config (`verify_jwt = false`)    | [`supabase/config.toml`](../supabase/config.toml) (`[functions.mcp]`)                          |
+| Consent screen                            | [`src/pages/OAuthConsentPage.tsx`](../src/pages/OAuthConsentPage.tsx) (route `/oauth/consent`) |
+
+### Tools exposed
+
+- `list_habits` — the user's habits with trait name/color.
+- `list_occurrences` — occurrences, optional `habit_id` / `from` / `to` / `limit`.
+- `log_occurrence` — create an occurrence for a habit.
+
+Add more by registering them in `index.ts` with `mcp.tool(...)`, reusing the
+shapes in `src/services/`.
+
+## One-time setup
+
+### 1. Enable the Supabase OAuth Server
+
+In the Supabase Dashboard → **Authentication → OAuth Server**:
+
+1. **Enable** the OAuth 2.1 server.
+2. Enable **Dynamic Client Registration** so MCP clients can self-register
+   (without it, every client must be registered by hand).
+3. Set the **authorization path** to your consent route:
+   `https://www.habitrack.io/oauth/consent` (and the local equivalent,
+   `http://localhost:5173/oauth/consent`, for dev).
+
+> Requires asymmetric JWT signing keys (RS256/ES256). If the project is still on
+> the legacy shared HS256 secret, migrate to signing keys first
+> (Settings → JWT Keys) — `auth.ts` verifies via the JWKS endpoint.
+
+### 2. Deploy the Edge Function
+
+```bash
+supabase functions deploy mcp           # remote
+# or, locally:
+supabase functions serve mcp            # http://localhost:54321/functions/v1/mcp
+```
+
+`SUPABASE_URL` and `SUPABASE_ANON_KEY` are injected automatically for deployed
+functions. For `supabase functions serve`, put them in `supabase/functions/.env`
+(or pass `--env-file`).
+
+The function's public URL is the MCP endpoint:
+
+```
+https://<project-ref>.supabase.co/functions/v1/mcp
+```
+
+## Testing
+
+### A. Token verification + RLS (the important checks)
+
+1. Run the OAuth flow once by hand to get an access token:
+   - Build an `/auth/v1/oauth/authorize?...` URL (response_type=code, client_id,
+     redirect_uri, code_challenge, code_challenge_method=S256, scope).
+   - Approve on `/oauth/consent`, grab the `code` from the callback, exchange it
+     at `/auth/v1/oauth/token` for an `access_token`.
+   - (Easier: let MCP Inspector do this — see C.)
+
+2. Call a tool with the token and confirm you get **only your** data:
+
+   ```bash
+   curl -s https://<ref>.supabase.co/functions/v1/mcp \
+     -H "Authorization: Bearer $ACCESS_TOKEN" \
+     -H "Accept: application/json, text/event-stream" \
+     -H "Content-Type: application/json" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
+          "params":{"name":"list_habits","arguments":{}}}'
+   ```
+
+3. **Cross-user check (do not skip):** repeat with user B's token and confirm you
+   never see user A's habits/occurrences. This proves RLS is enforced through the
+   OAuth token, not just in the app UI.
+
+4. **Unauthenticated discovery** must work without a token:
+
+   ```bash
+   curl -s https://<ref>.supabase.co/functions/v1/mcp/.well-known/oauth-protected-resource
+   # → { "resource": "...", "authorization_servers": ["https://<ref>.supabase.co/auth/v1"], ... }
+   ```
+
+   And a tool call with no token must return `401` with a `WWW-Authenticate`
+   header pointing at that discovery document.
+
+### B. Consent page
+
+Visit `/oauth/consent?authorization_id=<id>` (an id from a real `/authorize`
+redirect). Logged out → bounced to `/account`; logged in → client name + scopes
+render and Allow/Deny redirect back to the client.
+
+### C. MCP Inspector (full loop)
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Point it at the function URL with **Streamable HTTP** transport. It runs the
+whole discovery → DCR → OAuth → consent → tools loop interactively.
+
+### D. End-to-end in a real client
+
+Add the function URL as a **custom connector** in Claude or ChatGPT and watch it
+register, prompt for consent, and call the tools.
+
+## Notes / gotchas
+
+- `verify_jwt = false` is **required** on `[functions.mcp]`: the platform's
+  built-in gate would reject the unauthenticated discovery handshake before our
+  code runs. We verify the JWT ourselves in `auth.ts`.
+- Streamable HTTP clients must send
+  `Accept: application/json, text/event-stream`.
+- `currentUser` in `index.ts` is a per-invocation module variable; this is safe
+  because each Edge Function invocation handles a single request.
+- Scopes (`habits:read`, `habits:write`) are advisory today — RLS is the real
+  boundary. To make them enforced, check `user.scopes` inside each tool.
+
+```
+
+```

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -7,7 +7,7 @@ Supabase OAuth 2.1 server, so no separate auth system is needed.
 
 ## How it works
 
-```
+```text
 MCP client (ChatGPT / Claude)
   │  1. GET <mcp>/.well-known/oauth-protected-resource  → discovers the Supabase auth server
   │  2. Dynamic Client Registration + OAuth 2.1 (PKCE) against Supabase
@@ -40,12 +40,31 @@ server.
 
 ### Tools exposed
 
-- `list_habits` — the user's habits with trait name/color.
-- `list_occurrences` — occurrences, optional `habit_id` / `from` / `to` / `limit`.
+Read tools return a lean core row by default and accept an `include` array to
+embed related data only when asked — keeping default payloads small.
+
+- `list_habits` — the user's habits. `include`: `trait`, `metrics` (metric
+  definitions), `stocks` (with their metric defaults).
+- `list_occurrences` — occurrences, optional `habit_id` / `from` / `to` /
+  `limit`. `include`: `habit` (with trait + metric definitions), `metrics`
+  (recorded values), `stock_usages`. A recorded value's JSONB shape depends on
+  its metric `type`; include `habit` to get the definition needed to interpret
+  it (the tool description spells out the per-type shapes).
+- `list_notes` — the user's notes (attached to an occurrence or a day/week/month
+  period), optional `from` / `to` / `limit`. `include`: `habit` (the linked
+  occurrence and its habit). A date range filters on the note's **target date**
+  — the occurrence's time for occurrence notes, the `period_date` for period
+  notes — not `created_at`, matching the app's `listNotes` two-query strategy.
 - `log_occurrence` — create an occurrence for a habit.
 
-Add more by registering them in `index.ts` with `mcp.tool(...)`, reusing the
-shapes in `src/services/`.
+The `include` joins mirror what `src/services/` selects, trimmed to explicit
+column lists (no `*`) and returned as snake_case straight from the DB. Add more
+tools by registering them in `index.ts` with `mcp.tool(...)`.
+
+> Scopes: read tools require `habits:read`, `log_occurrence` requires
+> `habits:write`. These claims are only present on tokens minted through the
+> OAuth consent flow — a plain Supabase session token (no `scope` claim) is
+> rejected by design.
 
 ## One-time setup
 
@@ -78,7 +97,7 @@ functions. For `supabase functions serve`, put them in `supabase/functions/.env`
 
 The function's public URL is the MCP endpoint:
 
-```
+```text
 https://<project-ref>.supabase.co/functions/v1/mcp
 ```
 
@@ -145,11 +164,10 @@ register, prompt for consent, and call the tools.
   code runs. We verify the JWT ourselves in `auth.ts`.
 - Streamable HTTP clients must send
   `Accept: application/json, text/event-stream`.
-- `currentUser` in `index.ts` is a per-invocation module variable; this is safe
-  because each Edge Function invocation handles a single request.
-- Scopes (`habits:read`, `habits:write`) are advisory today — RLS is the real
-  boundary. To make them enforced, check `user.scopes` inside each tool.
-
-```
-
-```
+- The authenticated user is threaded per request via mcp-lite's `authInfo`
+  (`httpHandler(req, { authInfo })`), so each tool handler reads it from its own
+  `ctx` — no shared mutable state and no risk of cross-request leakage.
+- Scopes (`habits:read`, `habits:write`) are enforced per tool via `ensureScope`
+  in `index.ts`; RLS remains the data-access boundary. The scopes must actually
+  be granted on the token (requested by the client and consented to), or those
+  tools will be rejected.

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -6,6 +6,7 @@ import {
   HabitsPage,
   AccountPage,
   DayCalendarPage,
+  OAuthConsentPage,
   HabitDetailsPage,
   WeekCalendarPage,
   MonthCalendarPage,
@@ -30,6 +31,7 @@ const AppRoutes = () => {
       <Route path="/habits/:habitId" element={<HabitDetailsPage />} />
       <Route path="/notes" element={<NotesPage />} />
       <Route path="/account" element={<AccountPage />} />
+      <Route path="/oauth/consent" element={<OAuthConsentPage />} />
       <Route path="*" element={<Navigate replace to="/calendar/month" />} />
     </Routes>
   );

--- a/src/pages/OAuthConsentPage.tsx
+++ b/src/pages/OAuthConsentPage.tsx
@@ -1,0 +1,208 @@
+import { Card, Chip, Alert, Button, Spinner } from '@heroui/react';
+import type { OAuthAuthorizationDetails } from '@supabase/supabase-js';
+import React from 'react';
+
+import { useUser } from '@stores';
+import { supabaseClient } from '@utils';
+
+// Human-readable labels for the scopes we expose. Anything unknown is shown
+// verbatim so new scopes still render sensibly.
+const SCOPE_LABELS: Record<string, string> = {
+  email: 'Your email address',
+  'habits:read': 'Read your habits and occurrences',
+  'habits:write': 'Create and update occurrences',
+  openid: 'Verify your identity',
+  profile: 'Your basic profile',
+};
+
+/**
+ * Consent screen for the Supabase OAuth 2.1 server.
+ *
+ * Supabase redirects users here (the configured "authorization path") with an
+ * `authorization_id` query param after it has validated an /authorize request
+ * from an MCP client. We show what the client is asking for and let the user
+ * approve or deny; the SDK then redirects back to the client with a code.
+ *
+ * Route: /oauth/consent
+ */
+const OAuthConsentPage = () => {
+  const user = useUser();
+  const [details, setDetails] =
+    React.useState<OAuthAuthorizationDetails | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  const authorizationId = React.useMemo(() => {
+    return new URLSearchParams(window.location.search).get('authorization_id');
+  }, []);
+
+  React.useEffect(() => {
+    if (!authorizationId) {
+      setError('Missing authorization_id. This page expects an OAuth request.');
+      setIsLoading(false);
+
+      return;
+    }
+
+    // `useUser` returns null both while the session is still loading and when
+    // the user is genuinely logged out. Confirm with getSession before
+    // deciding to bounce to login, so we don't redirect mid-load.
+    if (user === null) {
+      supabaseClient.auth.getSession().then(({ data }) => {
+        if (!data.session) {
+          const returnTo = encodeURIComponent(
+            window.location.pathname + window.location.search
+          );
+          window.location.href = `/account?returnTo=${returnTo}`;
+        }
+      });
+
+      return;
+    }
+
+    supabaseClient.auth.oauth
+      .getAuthorizationDetails(authorizationId)
+      .then(({ data, error: detailsError }) => {
+        if (detailsError) {
+          throw detailsError;
+        }
+
+        // Already consented previously → Supabase hands back a redirect URL.
+        if ('redirect_url' in data) {
+          window.location.href = data.redirect_url;
+
+          return;
+        }
+
+        setDetails(data);
+      })
+      .catch((err: Error) => {
+        setError(err.message);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [authorizationId, user]);
+
+  const decide = async (approve: boolean) => {
+    if (!authorizationId) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      // skipBrowserRedirect: true so we control navigation explicitly.
+      const { data, error: decisionError } = approve
+        ? await supabaseClient.auth.oauth.approveAuthorization(
+            authorizationId,
+            { skipBrowserRedirect: true }
+          )
+        : await supabaseClient.auth.oauth.denyAuthorization(authorizationId, {
+            skipBrowserRedirect: true,
+          });
+
+      if (decisionError) {
+        throw decisionError;
+      }
+
+      window.location.href = data.redirect_url;
+    } catch (err) {
+      setError((err as Error).message);
+      setIsSubmitting(false);
+    }
+  };
+
+  const title = <title>Authorize Access | Habitrack</title>;
+
+  if (isLoading) {
+    return (
+      <div className="mt-16 flex w-full flex-col items-center gap-3">
+        {title}
+        <Spinner />
+        <p className="text-default-500 text-sm">
+          Loading authorization request…
+        </p>
+      </div>
+    );
+  }
+
+  if (error || !details) {
+    return (
+      <div className="mt-16 flex w-full justify-center px-4">
+        {title}
+        <Alert status="danger" className="w-full max-w-md">
+          <Alert.Indicator />
+          <Alert.Content>
+            <Alert.Title className="font-bold">
+              Couldn&apos;t load this authorization request
+            </Alert.Title>
+            <Alert.Description>{error ?? 'Unknown error.'}</Alert.Description>
+          </Alert.Content>
+        </Alert>
+      </div>
+    );
+  }
+
+  const scopes = details.scope.split(' ').filter(Boolean);
+
+  return (
+    <div className="mt-12 flex w-full justify-center px-4">
+      {title}
+      <Card className="w-full max-w-md">
+        <Card.Header className="flex-col items-start gap-1">
+          <h1 className="text-xl font-bold">Authorize {details.client.name}</h1>
+          <p className="text-default-500 text-sm">
+            <span className="font-medium">{details.client.name}</span> wants to
+            access your Habitrack account
+            {details.user.email ? ` (${details.user.email})` : ''}.
+          </p>
+        </Card.Header>
+        <Card.Content className="gap-4">
+          <div>
+            <p className="text-default-600 mb-2 text-sm font-medium">
+              This will allow it to:
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {scopes.map((scope) => {
+                return (
+                  <Chip size="sm" key={scope} variant="soft">
+                    {SCOPE_LABELS[scope] ?? scope}
+                  </Chip>
+                );
+              })}
+            </div>
+          </div>
+          <p className="text-default-400 text-xs">
+            Redirects to{' '}
+            <span className="font-mono">{details.redirect_uri}</span>. You can
+            revoke this access at any time from your account settings.
+          </p>
+        </Card.Content>
+        <Card.Footer className="justify-end gap-2">
+          <Button
+            variant="outline"
+            isDisabled={isSubmitting}
+            onPress={() => {
+              return decide(false);
+            }}
+          >
+            Deny
+          </Button>
+          <Button
+            variant="primary"
+            isDisabled={isSubmitting}
+            onPress={() => {
+              return decide(true);
+            }}
+          >
+            Allow
+          </Button>
+        </Card.Footer>
+      </Card>
+    </div>
+  );
+};
+
+export default OAuthConsentPage;

--- a/src/pages/OAuthConsentPage.tsx
+++ b/src/pages/OAuthConsentPage.tsx
@@ -2,15 +2,14 @@ import { Card, Chip, Alert, Button, Spinner } from '@heroui/react';
 import type { OAuthAuthorizationDetails } from '@supabase/supabase-js';
 import React from 'react';
 
-import { useUser } from '@stores';
-import { supabaseClient } from '@utils';
+import { supabaseClient, getErrorMessage } from '@utils';
 
 // Human-readable labels for the scopes we expose. Anything unknown is shown
 // verbatim so new scopes still render sensibly.
 const SCOPE_LABELS: Record<string, string> = {
   email: 'Your email address',
-  'habits:read': 'Read your habits and occurrences',
-  'habits:write': 'Create and update occurrences',
+  'habits:read': 'Read your habits, occurrences, and notes',
+  'habits:write': 'Log occurrences for your habits',
   openid: 'Verify your identity',
   profile: 'Your basic profile',
 };
@@ -26,10 +25,10 @@ const SCOPE_LABELS: Record<string, string> = {
  * Route: /oauth/consent
  */
 const OAuthConsentPage = () => {
-  const user = useUser();
   const [details, setDetails] =
     React.useState<OAuthAuthorizationDetails | null>(null);
   const [error, setError] = React.useState<string | null>(null);
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
@@ -45,45 +44,51 @@ const OAuthConsentPage = () => {
       return;
     }
 
-    // `useUser` returns null both while the session is still loading and when
-    // the user is genuinely logged out. Confirm with getSession before
-    // deciding to bounce to login, so we don't redirect mid-load.
-    if (user === null) {
-      supabaseClient.auth.getSession().then(({ data }) => {
-        if (!data.session) {
-          const returnTo = encodeURIComponent(
-            window.location.pathname + window.location.search
-          );
-          window.location.href = `/account?returnTo=${returnTo}`;
-        }
-      });
+    // Resolve the session ourselves rather than waiting on the global user
+    // store to hydrate — `getSession` reads the persisted session directly, so
+    // the page never stalls on the spinner awaiting external state. No session
+    // means genuinely logged out: bounce to login and return here after.
+    const run = async () => {
+      const {
+        data: { session },
+      } = await supabaseClient.auth.getSession();
 
-      return;
-    }
+      if (!session) {
+        const returnTo = encodeURIComponent(
+          window.location.pathname + window.location.search
+        );
+        window.location.href = `/account?returnTo=${returnTo}`;
 
-    supabaseClient.auth.oauth
-      .getAuthorizationDetails(authorizationId)
-      .then(({ data, error: detailsError }) => {
-        if (detailsError) {
-          throw detailsError;
-        }
+        return;
+      }
 
-        // Already consented previously → Supabase hands back a redirect URL.
-        if ('redirect_url' in data) {
-          window.location.href = data.redirect_url;
+      const { data, error: detailsError } =
+        await supabaseClient.auth.oauth.getAuthorizationDetails(
+          authorizationId
+        );
 
-          return;
-        }
+      if (detailsError) {
+        throw detailsError;
+      }
 
-        setDetails(data);
-      })
+      // Already consented previously → Supabase hands back a redirect URL.
+      if ('redirect_url' in data) {
+        window.location.href = data.redirect_url;
+
+        return;
+      }
+
+      setDetails(data);
+    };
+
+    run()
       .catch((err: Error) => {
         setError(err.message);
       })
       .finally(() => {
         setIsLoading(false);
       });
-  }, [authorizationId, user]);
+  }, [authorizationId]);
 
   const decide = async (approve: boolean) => {
     if (!authorizationId) {
@@ -91,6 +96,7 @@ const OAuthConsentPage = () => {
     }
 
     setIsSubmitting(true);
+    setSubmitError(null);
 
     try {
       // skipBrowserRedirect: true so we control navigation explicitly.
@@ -108,8 +114,11 @@ const OAuthConsentPage = () => {
       }
 
       window.location.href = data.redirect_url;
-    } catch (err) {
-      setError((err as Error).message);
+    } catch (error) {
+      // A transient approve/deny failure is retryable — surface it inline on
+      // the consent card rather than tripping the fatal "couldn't load" screen.
+      setSubmitError(getErrorMessage(error));
+    } finally {
       setIsSubmitting(false);
     }
   };
@@ -179,6 +188,14 @@ const OAuthConsentPage = () => {
             <span className="font-mono">{details.redirect_uri}</span>. You can
             revoke this access at any time from your account settings.
           </p>
+          {submitError && (
+            <Alert status="danger">
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Description>{submitError}</Alert.Description>
+              </Alert.Content>
+            </Alert>
+          )}
         </Card.Content>
         <Card.Footer className="justify-end gap-2">
           <Button

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -5,4 +5,5 @@ export { default as HabitDetailsPage } from './HabitDetailsPage';
 export { default as HabitsPage } from './HabitsPage';
 export { default as MonthCalendarPage } from './MonthCalendarPage';
 export { default as NotesPage } from './NotesPage';
+export { default as OAuthConsentPage } from './OAuthConsentPage';
 export { default as WeekCalendarPage } from './WeekCalendarPage';

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -232,6 +232,14 @@ enabled = true
 policy = "oneshot"
 inspector_port = 8083
 
+# MCP server exposing habits/occurrences to OAuth-authenticated MCP clients.
+# verify_jwt is false on purpose: the function performs its own JWT verification
+# and must serve the unauthenticated OAuth discovery handshake (see
+# supabase/functions/mcp/auth.ts).
+[functions.mcp]
+enabled = true
+verify_jwt = false
+
 [analytics]
 enabled = false
 port = 54327

--- a/supabase/functions/mcp/auth.ts
+++ b/supabase/functions/mcp/auth.ts
@@ -1,0 +1,113 @@
+// OAuth / JWT plumbing for the Habitrack MCP server.
+//
+// The MCP server is a *protected resource*: it does not run the OAuth flow
+// itself. It only (1) tells clients where to authenticate via the
+// `oauth-protected-resource` discovery document, and (2) verifies the Bearer
+// access token that clients present on every request.
+//
+// Tokens are standard Supabase JWTs (RS256/ES256, signed by the project's
+// asymmetric keys). We verify them against the project JWKS. Because the token
+// carries the user's `sub`, a Supabase client created with it is automatically
+// scoped to that user by Row Level Security — no per-user checks needed here.
+
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'npm:jose@^5.9.6';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+
+// The issuer/JWKS for project-issued JWTs live under /auth/v1.
+const ISSUER = `${SUPABASE_URL}/auth/v1`;
+const JWKS = createRemoteJWKSet(
+  new URL(`${ISSUER}/.well-known/jwks.json`)
+);
+
+export type AuthedUser = {
+  /** Supabase user id (JWT `sub`). */
+  userId: string;
+  /** OAuth client that obtained the token (JWT `client_id`), if any. */
+  clientId?: string;
+  /** Raw access token — forwarded to PostgREST so RLS applies. */
+  token: string;
+  /** Granted OAuth scopes, space-separated in the token. */
+  scopes: string[];
+  email?: string;
+};
+
+/**
+ * The resource server's base URL, e.g.
+ * https://<ref>.supabase.co/functions/v1/mcp
+ */
+export const resourceUrl = () =>
+  `${SUPABASE_URL}/functions/v1/mcp`;
+
+/**
+ * RFC 9728 protected-resource metadata. MCP clients fetch this first to learn
+ * which authorization server to use. We point them at the Supabase OAuth
+ * server, which exposes /authorize, /token, DCR and JWKS.
+ */
+export const protectedResourceMetadata = () => ({
+  resource: resourceUrl(),
+  authorization_servers: [ISSUER],
+  bearer_methods_supported: ['header'],
+  scopes_supported: ['openid', 'email', 'profile', 'habits:read', 'habits:write'],
+});
+
+/** 401 challenge that tells the client where the discovery document lives. */
+export const unauthorized = (detail = 'invalid_token') => {
+  const challenge =
+    `Bearer resource_metadata="${resourceUrl()}/.well-known/oauth-protected-resource", ` +
+    `error="${detail}"`;
+
+  return new Response(
+    JSON.stringify({ error: detail }),
+    {
+      status: 401,
+      headers: {
+        'content-type': 'application/json',
+        'www-authenticate': challenge,
+      },
+    }
+  );
+};
+
+/**
+ * Verify the Authorization: Bearer <jwt> header. Returns the authed user, or
+ * null when the token is missing/invalid (caller should emit `unauthorized`).
+ */
+export const authenticate = async (
+  req: Request
+): Promise<AuthedUser | null> => {
+  const header = req.headers.get('authorization') ?? '';
+
+  if (!header.toLowerCase().startsWith('bearer ')) {
+    return null;
+  }
+
+  const token = header.slice(7).trim();
+
+  try {
+    const { payload } = await jwtVerify(token, JWKS, {
+      issuer: ISSUER,
+      audience: 'authenticated',
+    });
+
+    const p = payload as JWTPayload & {
+      client_id?: string;
+      email?: string;
+      scope?: string;
+    };
+
+    if (!p.sub) {
+      return null;
+    }
+
+    return {
+      userId: p.sub,
+      clientId: p.client_id,
+      token,
+      scopes: p.scope ? p.scope.split(' ') : [],
+      email: p.email,
+    };
+  } catch {
+    return null;
+  }
+};

--- a/supabase/functions/mcp/deno.json
+++ b/supabase/functions/mcp/deno.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["deno.window", "deno.ns"],
+    "strict": true
+  },
+  "imports": {
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@^2.108.0",
+    "mcp-lite": "npm:mcp-lite@0.8.2",
+    "zod": "npm:zod@^4.1.12"
+  }
+}

--- a/supabase/functions/mcp/deno.lock
+++ b/supabase/functions/mcp/deno.lock
@@ -1,0 +1,84 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@supabase/supabase-js@^2.108.0": "2.108.1",
+    "npm:jose@^5.9.6": "5.10.0",
+    "npm:mcp-lite@0.8.2": "0.8.2",
+    "npm:zod@^4.1.12": "4.4.3"
+  },
+  "npm": {
+    "@standard-schema/spec@1.1.0": {
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "@supabase/auth-js@2.108.1": {
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.108.1": {
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.2": {
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A=="
+    },
+    "@supabase/postgrest-js@2.108.1": {
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.108.1": {
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.108.1": {
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "@supabase/supabase-js@2.108.1": {
+      "integrity": "sha512-V/1hRKLSCJ0zEL+9QFRBUtivvePfOsaAYQmC0HhFNSHC2F3xFs4jSF3YhkLmzex6E4V4FGvmBDOP72D/53NnZA==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "jose@5.10.0": {
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="
+    },
+    "mcp-lite@0.8.2": {
+      "integrity": "sha512-v78gCsmOI9cGhUsu8xRZ8NEZ6AOFPaAxm4xarP6Dhro3l9HY6Voo43MNuX+CO5oT8gpRfgJ5bMJLTSCFsp+4Kg==",
+      "dependencies": [
+        "@standard-schema/spec"
+      ]
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "zod@4.4.3": {
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@supabase/supabase-js@^2.108.0",
+      "npm:mcp-lite@0.8.2",
+      "npm:zod@^4.1.12"
+    ]
+  }
+}

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -10,7 +10,7 @@
 // ourselves in `authenticate()`.
 
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import { McpServer, StreamableHttpTransport } from 'mcp-lite';
+import { McpServer, StreamableHttpTransport, type Ctx } from 'mcp-lite';
 import { z } from 'zod';
 
 import {
@@ -30,22 +30,54 @@ const userClient = (user: AuthedUser): SupabaseClient =>
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-// The current authed user for the in-flight request. mcp-lite tool handlers
-// don't receive the raw Request, so we stash the user per request before
-// dispatching. Edge Function invocations are single-request, so this is safe.
-let currentUser: AuthedUser | null = null;
+// The authenticated user is threaded per request via mcp-lite's `authInfo`
+// (set on `httpHandler(req, { authInfo })`), so each tool handler reads it from
+// its own `ctx` — no shared mutable state, no cross-request leakage.
+const userFromContext = (ctx: Ctx): AuthedUser => {
+  const user = ctx.authInfo?.extra?.user as AuthedUser | undefined;
 
-const requireUser = (): AuthedUser => {
-  if (!currentUser) {
+  if (!user) {
     throw new Error('Not authenticated');
   }
 
-  return currentUser;
+  return user;
+};
+
+// Reject the request unless the token was granted the scope a tool needs.
+const ensureScope = (user: AuthedUser, scope: string): AuthedUser => {
+  if (!user.scopes.includes(scope)) {
+    throw new Error(`Missing required scope: ${scope}`);
+  }
+
+  return user;
 };
 
 const ok = (data: unknown) => ({
   content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
 });
+
+// Build a PostgREST select string from a base column list plus the embedded
+// resources a client opted into via `include`. Keeping the base lean and the
+// joins opt-in keeps default payloads small while letting clients pull the
+// full picture (stocks, metrics, etc.) when they ask. Curated column lists —
+// not `*` — so payloads stay stable and free of internal columns.
+const buildSelect = (
+  base: string,
+  include: string[],
+  joins: Record<string, string>
+): string => {
+  const parts = [base];
+
+  for (const key of include) {
+    const join = joins[key];
+
+    if (join) {
+      parts.push(join);
+    }
+  }
+
+  return parts.join(',');
+};
 
 const mcp = new McpServer({
   name: 'habitrack',
@@ -53,16 +85,55 @@ const mcp = new McpServer({
   schemaAdapter: (schema) => z.toJSONSchema(schema as z.ZodType),
 });
 
+// Recorded metric values are stored as JSONB whose shape depends on the metric
+// definition's `type`. Surfacing the mapping in the tool descriptions lets a
+// client interpret `metric_values[].value` without guessing.
+const METRIC_VALUE_SHAPES =
+  'A metric definition\'s `type` determines the JSONB shape of a recorded ' +
+  '`value`: number/percentage/scale → {numericValue}; duration → ' +
+  '{durationMs}; range → {rangeFrom,rangeTo}; choice → {selectedOption} or ' +
+  '{selectedOptions}; boolean → {booleanValue}; text → {textValue}. The ' +
+  "definition's `config` (JSONB) holds type-specific settings (units, min/max, " +
+  'options, labels, etc.).';
+
+const HABIT_INCLUDES = ['trait', 'metrics', 'stocks'] as const;
+
+const HABIT_JOINS: Record<string, string> = {
+  trait: 'trait:traits(id, name, color)',
+  metrics:
+    'metric_definitions:habit_metrics(id, name, type, config, sort_order, is_required)',
+  stocks:
+    'stocks:habit_stocks(id, name, cost, currency, total_items, remaining_items, is_depleted, purchased_at, metric_defaults:habit_stock_metric_defaults(id, habit_metric_id, value, should_compound))',
+};
+
 mcp.tool('list_habits', {
   description:
-    "List the authenticated user's habits, including trait name and color.",
-  inputSchema: z.object({}),
-  handler: async () => {
-    const supabase = userClient(requireUser());
+    "List the authenticated user's habits. By default returns the core habit " +
+    'fields; pass `include` to embed the trait, metric definitions, and/or ' +
+    'stocks (with their metric defaults). ' +
+    METRIC_VALUE_SHAPES,
+  inputSchema: z.object({
+    include: z
+      .array(z.enum(HABIT_INCLUDES))
+      .default([])
+      .describe(
+        'Embedded resources to fetch: "trait", "metrics", "stocks". Omit for the lean row.'
+      ),
+  }),
+  handler: async (args: { include: string[] }, ctx: Ctx) => {
+    const supabase = userClient(
+      ensureScope(userFromContext(ctx), 'habits:read')
+    );
+
+    const select = buildSelect(
+      'id, name, description, icon_path',
+      args.include,
+      HABIT_JOINS
+    );
 
     const { data, error } = await supabase
       .from('habits')
-      .select('id, name, description, icon_path, trait:traits(name, color)')
+      .select(select)
       .order('name');
 
     if (error) {
@@ -73,9 +144,26 @@ mcp.tool('list_habits', {
   },
 });
 
+const OCCURRENCE_INCLUDES = ['habit', 'metrics', 'stock_usages'] as const;
+
+const OCCURRENCE_JOINS: Record<string, string> = {
+  habit:
+    'habit:habits(id, name, icon_path, trait:traits(id, name, color), metric_definitions:habit_metrics(id, name, type, config, sort_order, is_required))',
+  metrics:
+    'metric_values:occurrence_metric_values(id, habit_metric_id, value)',
+  stock_usages:
+    'stock_usages:occurrence_stock_usages(id, habit_stock_id, quantity)',
+};
+
 mcp.tool('list_occurrences', {
   description:
-    'List the user\'s habit occurrences (loggings) within an optional date range. Dates are ISO 8601.',
+    "List the user's habit occurrences (loggings) within an optional date " +
+    'range (ISO 8601). By default returns the core occurrence fields; pass ' +
+    '`include` to embed the habit (with trait + metric definitions), recorded ' +
+    'metric values, and/or stock usages. Each recorded value carries its ' +
+    '`habit_metric_id`; include `habit` to get the matching definition (its ' +
+    '`type` and `config`) needed to interpret it. ' +
+    METRIC_VALUE_SHAPES,
   inputSchema: z.object({
     habit_id: z
       .string()
@@ -88,18 +176,36 @@ mcp.tool('list_occurrences', {
       .describe('Inclusive lower bound, ISO timestamp.'),
     to: z.string().optional().describe('Inclusive upper bound, ISO timestamp.'),
     limit: z.number().int().min(1).max(500).default(100),
+    include: z
+      .array(z.enum(OCCURRENCE_INCLUDES))
+      .default([])
+      .describe(
+        'Embedded resources: "habit", "metrics" (recorded values), "stock_usages". Omit for the lean row.'
+      ),
   }),
-  handler: async (args: {
-    habit_id?: string;
-    from?: string;
-    to?: string;
-    limit: number;
-  }) => {
-    const supabase = userClient(requireUser());
+  handler: async (
+    args: {
+      habit_id?: string;
+      from?: string;
+      to?: string;
+      limit: number;
+      include: string[];
+    },
+    ctx: Ctx
+  ) => {
+    const supabase = userClient(
+      ensureScope(userFromContext(ctx), 'habits:read')
+    );
+
+    const select = buildSelect(
+      'id, habit_id, occurred_at, time_zone, created_at',
+      args.include,
+      OCCURRENCE_JOINS
+    );
 
     let query = supabase
       .from('occurrences')
-      .select('id, habit_id, occurred_at, time_zone, created_at')
+      .select(select)
       .order('occurred_at', { ascending: false })
       .limit(args.limit);
 
@@ -137,12 +243,15 @@ mcp.tool('log_occurrence', {
       .describe('IANA time zone, e.g. "Europe/Berlin".')
       .default('UTC'),
   }),
-  handler: async (args: {
-    habit_id: string;
-    occurred_at?: string;
-    time_zone: string;
-  }) => {
-    const user = requireUser();
+  handler: async (
+    args: {
+      habit_id: string;
+      occurred_at?: string;
+      time_zone: string;
+    },
+    ctx: Ctx
+  ) => {
+    const user = ensureScope(userFromContext(ctx), 'habits:write');
     const supabase = userClient(user);
 
     const { data, error } = await supabase
@@ -163,6 +272,142 @@ mcp.tool('log_occurrence', {
     }
 
     return ok(data);
+  },
+});
+
+const NOTE_INCLUDES = ['habit'] as const;
+
+const NOTE_BASE_COLUMNS =
+  'id, content, occurrence_id, period_kind, period_date, created_at, updated_at';
+
+// A note targets at most one occurrence; pull that occurrence's habit so
+// clients can attribute the note. Period notes have no occurrence → null.
+const NOTE_HABIT_EMBED =
+  'occurrence:occurrences(id, occurred_at, habit:habits(id, name, icon_path))';
+
+// The note's effective date is its occurrence's `occurred_at` (occurrence
+// notes) or its `period_date` (period notes) — not `created_at`. Range
+// filtering must therefore hit whichever target the note has, mirroring the
+// two-query strategy in src/services/notes.service.ts.
+const noteTargetDate = (note: Record<string, unknown>): string => {
+  const occurrence = note.occurrence as { occurred_at?: string } | null;
+
+  return (
+    occurrence?.occurred_at ??
+    (note.period_date as string | null) ??
+    (note.created_at as string)
+  );
+};
+
+mcp.tool('list_notes', {
+  description:
+    "List the user's notes. A note is attached either to an occurrence or to " +
+    'a time period (day/week/month). By default returns the core note fields; ' +
+    'pass `include: ["habit"]` to embed the linked occurrence and its habit. ' +
+    'When a date range is given it filters on the note\'s target date — the ' +
+    "occurrence's time for occurrence notes, the period date for period notes.",
+  inputSchema: z.object({
+    from: z
+      .string()
+      .optional()
+      .describe("Inclusive lower bound on the note's target date, ISO."),
+    to: z
+      .string()
+      .optional()
+      .describe("Inclusive upper bound on the note's target date, ISO."),
+    limit: z.number().int().min(1).max(500).default(100),
+    include: z
+      .array(z.enum(NOTE_INCLUDES))
+      .default([])
+      .describe('Embedded resources: "habit". Omit for the lean row.'),
+  }),
+  handler: async (
+    args: { from?: string; to?: string; limit: number; include: string[] },
+    ctx: Ctx
+  ) => {
+    const supabase = userClient(
+      ensureScope(userFromContext(ctx), 'habits:read')
+    );
+
+    const wantsHabit = args.include.includes('habit');
+    const hasRange = Boolean(args.from || args.to);
+
+    // No range → one simple query; the occurrence embed is optional.
+    if (!hasRange) {
+      const select = wantsHabit
+        ? `${NOTE_BASE_COLUMNS}, ${NOTE_HABIT_EMBED}`
+        : NOTE_BASE_COLUMNS;
+
+      const { data, error } = await supabase
+        .from('notes')
+        .select(select)
+        .order('created_at', { ascending: false })
+        .limit(args.limit);
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return ok(data);
+    }
+
+    // Range → two queries against the two possible target dates, then merge.
+    // Period notes are filtered on `period_date`; occurrence notes on the
+    // joined `occurred_at` via an inner join so out-of-range ones drop out.
+    // We always select the occurrence embed here (needed for sorting); it's
+    // stripped from the output below unless the client asked for `habit`.
+    const periodQuery = supabase
+      .from('notes')
+      .select(`${NOTE_BASE_COLUMNS}, ${NOTE_HABIT_EMBED}`)
+      .not('period_date', 'is', null);
+
+    const occurrenceQuery = supabase
+      .from('notes')
+      .select(
+        `${NOTE_BASE_COLUMNS}, occurrence:occurrences!inner(id, occurred_at, habit:habits(id, name, icon_path))`
+      );
+
+    if (args.from) {
+      periodQuery.gte('period_date', args.from);
+      occurrenceQuery.gte('occurrences.occurred_at', args.from);
+    }
+    if (args.to) {
+      periodQuery.lte('period_date', args.to);
+      occurrenceQuery.lte('occurrences.occurred_at', args.to);
+    }
+
+    const [periodResult, occurrenceResult] = await Promise.all([
+      periodQuery,
+      occurrenceQuery,
+    ]);
+
+    if (periodResult.error) {
+      throw new Error(periodResult.error.message);
+    }
+    if (occurrenceResult.error) {
+      throw new Error(occurrenceResult.error.message);
+    }
+
+    const byId = new Map<string, Record<string, unknown>>();
+    for (const note of [...periodResult.data, ...occurrenceResult.data]) {
+      byId.set(note.id as string, note as Record<string, unknown>);
+    }
+
+    const merged = [...byId.values()]
+      .sort((a, b) => noteTargetDate(b).localeCompare(noteTargetDate(a)))
+      .slice(0, args.limit)
+      .map((note) => {
+        if (wantsHabit) {
+          return note;
+        }
+
+        // Drop the occurrence embed we only fetched for filtering/sorting.
+        const { occurrence: _occurrence, ...rest } = note;
+
+        return rest;
+      });
+
+    return ok(merged);
   },
 });
 
@@ -203,16 +448,18 @@ Deno.serve(async (req) => {
     return res;
   }
 
-  currentUser = user;
-
-  try {
-    const res = await httpHandler(req);
-    for (const [k, v] of Object.entries(cors)) {
-      res.headers.set(k, v);
-    }
-
-    return res;
-  } finally {
-    currentUser = null;
+  // Thread the authed user through mcp-lite's request-local authInfo so each
+  // tool handler reads it from its own ctx (see userFromContext).
+  const res = await httpHandler(req, {
+    authInfo: {
+      token: user.token,
+      scopes: user.scopes,
+      extra: { user },
+    },
+  });
+  for (const [k, v] of Object.entries(cors)) {
+    res.headers.set(k, v);
   }
+
+  return res;
 });

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -1,0 +1,218 @@
+// Habitrack MCP server — Supabase Edge Function.
+//
+// Exposes a user's habits and occurrences to MCP clients (ChatGPT, Claude,
+// etc.) over the OAuth 2.1 flow that Supabase Auth provides. Every tool runs
+// against a Supabase client carrying the *caller's* access token, so existing
+// Row Level Security policies scope all data to that user automatically.
+//
+// Deploy with `verify_jwt = false` (see supabase/config.toml) so the
+// unauthenticated discovery handshake can reach this code; we verify the JWT
+// ourselves in `authenticate()`.
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { McpServer, StreamableHttpTransport } from 'mcp-lite';
+import { z } from 'zod';
+
+import {
+  authenticate,
+  protectedResourceMetadata,
+  unauthorized,
+  type AuthedUser,
+} from './auth.ts';
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY')!;
+
+// Per-request Supabase client bound to the user's token → RLS applies.
+const userClient = (user: AuthedUser): SupabaseClient =>
+  createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    global: { headers: { Authorization: `Bearer ${user.token}` } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+// The current authed user for the in-flight request. mcp-lite tool handlers
+// don't receive the raw Request, so we stash the user per request before
+// dispatching. Edge Function invocations are single-request, so this is safe.
+let currentUser: AuthedUser | null = null;
+
+const requireUser = (): AuthedUser => {
+  if (!currentUser) {
+    throw new Error('Not authenticated');
+  }
+
+  return currentUser;
+};
+
+const ok = (data: unknown) => ({
+  content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+});
+
+const mcp = new McpServer({
+  name: 'habitrack',
+  version: '1.0.0',
+  schemaAdapter: (schema) => z.toJSONSchema(schema as z.ZodType),
+});
+
+mcp.tool('list_habits', {
+  description:
+    "List the authenticated user's habits, including trait name and color.",
+  inputSchema: z.object({}),
+  handler: async () => {
+    const supabase = userClient(requireUser());
+
+    const { data, error } = await supabase
+      .from('habits')
+      .select('id, name, description, icon_path, trait:traits(name, color)')
+      .order('name');
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return ok(data);
+  },
+});
+
+mcp.tool('list_occurrences', {
+  description:
+    'List the user\'s habit occurrences (loggings) within an optional date range. Dates are ISO 8601.',
+  inputSchema: z.object({
+    habit_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe('Filter to a single habit id (UUID).'),
+    from: z
+      .string()
+      .optional()
+      .describe('Inclusive lower bound, ISO timestamp.'),
+    to: z.string().optional().describe('Inclusive upper bound, ISO timestamp.'),
+    limit: z.number().int().min(1).max(500).default(100),
+  }),
+  handler: async (args: {
+    habit_id?: string;
+    from?: string;
+    to?: string;
+    limit: number;
+  }) => {
+    const supabase = userClient(requireUser());
+
+    let query = supabase
+      .from('occurrences')
+      .select('id, habit_id, occurred_at, time_zone, created_at')
+      .order('occurred_at', { ascending: false })
+      .limit(args.limit);
+
+    if (args.habit_id !== undefined) {
+      query = query.eq('habit_id', args.habit_id);
+    }
+    if (args.from) {
+      query = query.gte('occurred_at', args.from);
+    }
+    if (args.to) {
+      query = query.lte('occurred_at', args.to);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return ok(data);
+  },
+});
+
+mcp.tool('log_occurrence', {
+  description:
+    'Log a new occurrence for one of the user\'s habits at a given time.',
+  inputSchema: z.object({
+    habit_id: z.string().uuid().describe('The habit to log (UUID).'),
+    occurred_at: z
+      .string()
+      .describe('When it happened, ISO 8601. Defaults to now if omitted.')
+      .optional(),
+    time_zone: z
+      .string()
+      .describe('IANA time zone, e.g. "Europe/Berlin".')
+      .default('UTC'),
+  }),
+  handler: async (args: {
+    habit_id: string;
+    occurred_at?: string;
+    time_zone: string;
+  }) => {
+    const user = requireUser();
+    const supabase = userClient(user);
+
+    const { data, error } = await supabase
+      .from('occurrences')
+      .insert({
+        habit_id: args.habit_id,
+        occurred_at: args.occurred_at ?? new Date().toISOString(),
+        time_zone: args.time_zone,
+        // user_id is enforced by the RLS WITH CHECK policy; we set it
+        // explicitly to satisfy the NOT NULL column.
+        user_id: user.userId,
+      })
+      .select('id, habit_id, occurred_at, time_zone')
+      .single();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return ok(data);
+  },
+});
+
+const transport = new StreamableHttpTransport();
+const httpHandler = transport.bind(mcp);
+
+const cors = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-headers':
+    'authorization, content-type, mcp-protocol-version, mcp-session-id',
+  'access-control-allow-methods': 'GET, POST, OPTIONS',
+  'access-control-expose-headers': 'mcp-session-id, www-authenticate',
+};
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: cors });
+  }
+
+  // RFC 9728 discovery — served unauthenticated so clients can bootstrap OAuth.
+  if (url.pathname.endsWith('/.well-known/oauth-protected-resource')) {
+    return new Response(JSON.stringify(protectedResourceMetadata()), {
+      headers: { 'content-type': 'application/json', ...cors },
+    });
+  }
+
+  // Everything else requires a valid Supabase OAuth access token.
+  const user = await authenticate(req);
+
+  if (!user) {
+    const res = unauthorized();
+    for (const [k, v] of Object.entries(cors)) {
+      res.headers.set(k, v);
+    }
+
+    return res;
+  }
+
+  currentUser = user;
+
+  try {
+    const res = await httpHandler(req);
+    for (const [k, v] of Object.entries(cors)) {
+      res.headers.set(k, v);
+    }
+
+    return res;
+  } finally {
+    currentUser = null;
+  }
+});


### PR DESCRIPTION
## Description

Introduce a Supabase Edge Function that implements an MCP (Model Context Protocol) protected-resource server and the corresponding consent UI. Files added: supabase/functions/mcp (index.ts implements MCP tools: list_habits, list_occurrences, log_occurrence; auth.ts verifies Supabase JWTs against JWKS and exposes RFC 9728 discovery metadata), deno.json (dependencies) and deno.lock. Update supabase/config.toml to enable the mcp function with verify_jwt = false so the function performs its own JWT verification. Add a React consent page (src/pages/OAuthConsentPage.tsx), register it in routes and page exports, and include documentation (docs/MCP_SERVER.md) explaining setup, testing, and security notes (RLS-based authorization and token forwarding).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OAuth consent page for users to approve or deny third-party authorization requests.
  * Enabled Habitrack to function as a remote MCP server, providing secure per-user access to habits, occurrences, and notes.

* **Documentation**
  * Added a comprehensive MCP server setup and testing guide covering OAuth flows, scopes, discovery, and operational notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->