### PR TITLE
fix(mcp): remove custom oauth scopes and scope checks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,7 +32,12 @@
       "mcp__heroui-migration__get_hooks_migration_guide",
       "Bash(git checkout:*)",
       "Bash(yarn install:*)",
-      "Bash(python3 -c ':*)"
+      "Bash(python3 -c ':*)",
+      "mcp__chrome-devtools__take_snapshot",
+      "mcp__chrome-devtools__fill",
+      "mcp__chrome-devtools__click",
+      "mcp__chrome-devtools__list_network_requests",
+      "mcp__chrome-devtools__get_network_request"
     ]
   },
   "hooks": {

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -61,14 +61,44 @@ The `include` joins mirror what `src/services/` selects, trimmed to explicit
 column lists (no `*`) and returned as snake_case straight from the DB. Add more
 tools by registering them in `index.ts` with `mcp.tool(...)`.
 
-> Scopes: read tools require `habits:read`, `log_occurrence` requires
-> `habits:write`. These claims are only present on tokens minted through the
-> OAuth consent flow — a plain Supabase session token (no `scope` claim) is
-> rejected by design.
+> Scopes: Supabase's OAuth server only negotiates the standard scopes
+> (`openid` / `profile` / `email` / `phone`). Custom scopes such as
+> `habits:read` are **rejected at `/authorize`**, so we don't advertise or
+> require them. Any valid OAuth-issued token can call every tool; the read vs.
+> write distinction is enforced by which tools exist, and **RLS** is the data
+> boundary (each query runs as the token's user). `authenticate()` rejects
+> missing/invalid tokens with a `401`.
 
 ## One-time setup
 
-### 1. Enable the Supabase OAuth Server
+### 1. Migrate JWT signing keys to asymmetric (REQUIRED — do this first)
+
+In the Supabase Dashboard → **Settings → JWT Keys**, rotate the project's signing
+key from the legacy **HS256** shared secret to an asymmetric key (**ECC P-256**,
+i.e. ES256 — the recommended/only option in the dashboard; RS256 also works).
+
+This is **not optional** for the OAuth flow. The `openid` scope makes Supabase
+mint an OpenID ID token, which **cannot be signed with HS256**. On an HS256
+project the token exchange fails with:
+
+```text
+POST /oauth/token → 500: "Error generating ID token"
+                        "HS256 is not supported for ID token signing"
+```
+
+The visible symptom is misleading: the user reaches consent, clicks **Allow**,
+returns to the client, and only then sees a generic error — because no token was
+ever issued, so every subsequent MCP request is `401`. Confirm the fix by
+checking the JWKS is non-empty:
+
+```text
+GET https://<ref>.supabase.co/auth/v1/.well-known/jwks.json
+→ { "keys": [ { "alg": "ES256", "kty": "EC", ... } ] }   # not { "keys": [] }
+```
+
+`auth.ts` verifies incoming tokens against this JWKS.
+
+### 2. Enable the Supabase OAuth Server
 
 In the Supabase Dashboard → **Authentication → OAuth Server**:
 
@@ -79,11 +109,7 @@ In the Supabase Dashboard → **Authentication → OAuth Server**:
    `https://www.habitrack.io/oauth/consent` (and the local equivalent,
    `http://localhost:5173/oauth/consent`, for dev).
 
-> Requires asymmetric JWT signing keys (RS256/ES256). If the project is still on
-> the legacy shared HS256 secret, migrate to signing keys first
-> (Settings → JWT Keys) — `auth.ts` verifies via the JWKS endpoint.
-
-### 2. Deploy the Edge Function
+### 3. Deploy the Edge Function
 
 ```bash
 supabase functions deploy mcp           # remote
@@ -167,7 +193,7 @@ register, prompt for consent, and call the tools.
 - The authenticated user is threaded per request via mcp-lite's `authInfo`
   (`httpHandler(req, { authInfo })`), so each tool handler reads it from its own
   `ctx` — no shared mutable state and no risk of cross-request leakage.
-- Scopes (`habits:read`, `habits:write`) are enforced per tool via `ensureScope`
-  in `index.ts`; RLS remains the data-access boundary. The scopes must actually
-  be granted on the token (requested by the client and consented to), or those
-  tools will be rejected.
+- Tools are not scope-gated (see the scopes note above — Supabase rejects custom
+  scopes at `/authorize`). Authorization is: a valid OAuth-issued token + RLS.
+  If Supabase ever supports registering custom OAuth scopes, re-add per-tool
+  scope checks reading `ctx.authInfo.scopes`.

--- a/src/pages/OAuthConsentPage.tsx
+++ b/src/pages/OAuthConsentPage.tsx
@@ -8,8 +8,6 @@ import { supabaseClient, getErrorMessage } from '@utils';
 // verbatim so new scopes still render sensibly.
 const SCOPE_LABELS: Record<string, string> = {
   email: 'Your email address',
-  'habits:read': 'Read your habits, occurrences, and notes',
-  'habits:write': 'Log occurrences for your habits',
   openid: 'Verify your identity',
   profile: 'Your basic profile',
 };
@@ -174,6 +172,9 @@ const OAuthConsentPage = () => {
               This will allow it to:
             </p>
             <div className="flex flex-wrap gap-2">
+              <Chip size="sm" variant="soft">
+                Read and log your habits, occurrences, and notes
+              </Chip>
               {scopes.map((scope) => {
                 return (
                   <Chip size="sm" key={scope} variant="soft">

--- a/supabase/functions/mcp/auth.ts
+++ b/supabase/functions/mcp/auth.ts
@@ -48,7 +48,10 @@ export const protectedResourceMetadata = () => ({
   resource: resourceUrl(),
   authorization_servers: [ISSUER],
   bearer_methods_supported: ['header'],
-  scopes_supported: ['openid', 'email', 'profile', 'habits:read', 'habits:write'],
+  // Only the scopes Supabase's OAuth server actually negotiates. Custom scopes
+  // (e.g. habits:read) are rejected at /authorize, so advertising them here
+  // would break the flow — clients would request a scope that can't be granted.
+  scopes_supported: ['openid', 'email', 'profile'],
 });
 
 /** 401 challenge that tells the client where the discovery document lives. */

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -43,14 +43,13 @@ const userFromContext = (ctx: Ctx): AuthedUser => {
   return user;
 };
 
-// Reject the request unless the token was granted the scope a tool needs.
-const ensureScope = (user: AuthedUser, scope: string): AuthedUser => {
-  if (!user.scopes.includes(scope)) {
-    throw new Error(`Missing required scope: ${scope}`);
-  }
-
-  return user;
-};
+// Note on authorization: Supabase's OAuth server only negotiates the standard
+// scopes (openid/profile/email/phone) — custom scopes like "habits:read" are
+// rejected at /authorize, so we can't express read-vs-write granularity via
+// scopes. A successfully issued token already means the user consented to
+// connect their account, and RLS scopes every query to that user. The
+// read/write distinction is therefore enforced by which tools we expose, not
+// by scope checks. `authenticate()` rejects any missing/invalid token (401).
 
 const ok = (data: unknown) => ({
   content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
@@ -121,9 +120,7 @@ mcp.tool('list_habits', {
       ),
   }),
   handler: async (args: { include: string[] }, ctx: Ctx) => {
-    const supabase = userClient(
-      ensureScope(userFromContext(ctx), 'habits:read')
-    );
+    const supabase = userClient(userFromContext(ctx));
 
     const select = buildSelect(
       'id, name, description, icon_path',
@@ -193,9 +190,7 @@ mcp.tool('list_occurrences', {
     },
     ctx: Ctx
   ) => {
-    const supabase = userClient(
-      ensureScope(userFromContext(ctx), 'habits:read')
-    );
+    const supabase = userClient(userFromContext(ctx));
 
     const select = buildSelect(
       'id, habit_id, occurred_at, time_zone, created_at',
@@ -251,7 +246,7 @@ mcp.tool('log_occurrence', {
     },
     ctx: Ctx
   ) => {
-    const user = ensureScope(userFromContext(ctx), 'habits:write');
+    const user = userFromContext(ctx);
     const supabase = userClient(user);
 
     const { data, error } = await supabase
@@ -325,9 +320,7 @@ mcp.tool('list_notes', {
     args: { from?: string; to?: string; limit: number; include: string[] },
     ctx: Ctx
   ) => {
-    const supabase = userClient(
-      ensureScope(userFromContext(ctx), 'habits:read')
-    );
+    const supabase = userClient(userFromContext(ctx));
 
     const wantsHabit = args.include.includes('habit');
     const hasRange = Boolean(args.from || args.to);


### PR DESCRIPTION
## Description

Stop advertising and enforcing custom OAuth scopes (e.g. habits:read/habits:write). Supabase rejects custom scopes at /authorize, so the code now only advertises standard scopes and no longer performs per-tool scope checks; authorization is a valid OAuth-issued token + RLS. Docs updated to require migrating JWT signing to asymmetric keys (ES256) for OpenID ID tokens and to describe the JWKS verification. OAuth consent UI simplified to present a single habits permission chip. Also added several chrome-devtools commands to .claude settings.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified OAuth scope handling: system now negotiates only standard OpenID scopes, rejecting custom scopes.
  * Added explicit guidance on migrating JWT signing keys to asymmetric signing (ES256).
  * Updated authorization model documentation to reflect token validation and database-level access control.

* **User Interface**
  * Updated OAuth consent page to display revised messaging about permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->