### PR TITLE
feat(calendar): move controls and filters to aside in week mode

### DIFF
--- a/src/components/calendar/CalendarNavigation.tsx
+++ b/src/components/calendar/CalendarNavigation.tsx
@@ -23,7 +23,6 @@ import { getWeeksOfYear } from '@utils';
 import CalendarNavigationButtons from './CalendarNavigationButtons';
 
 export type MonthCalendarNavigationProps = {
-  className?: string;
   focusedDate: CalendarState['focusedDate'];
 };
 
@@ -31,10 +30,7 @@ const YEARS = Array.from({ length: 31 }, (_, i) => {
   return 2000 + i;
 });
 
-const CalendarNavigation = ({
-  className,
-  focusedDate,
-}: MonthCalendarNavigationProps) => {
+const CalendarNavigation = ({ focusedDate }: MonthCalendarNavigationProps) => {
   const timeZone = getLocalTimeZone();
   const filters = useCalendarFilters();
   const changeCalendarFilters = useCalendarFiltersChange();
@@ -106,146 +102,50 @@ const CalendarNavigation = ({
   };
 
   return (
-    <div className={cn('flex items-stretch justify-between gap-2', className)}>
-      <div className="mr-0 flex items-stretch gap-2">
-        <Select
-          variant="secondary"
-          value={monthSelectValue}
-          className="w-17.5 md:w-28"
-          isOpen={monthSelectState.isOpen}
-          onOpenChange={monthSelectState.setOpen}
-        >
-          <Label className="sr-only">Month</Label>
-          <Select.Trigger>
-            <Select.Value
-              render={() => {
-                return (
-                  <span className="flex items-center gap-1">
-                    {formatter.format(focusedDate.toDate(timeZone))}
-                  </span>
-                );
-              }}
-            />
-            <Select.Indicator />
-          </Select.Trigger>
-          <Select.Popover className="w-25 md:w-31.25">
-            <ListBox>
-              <ListBox.Section>
-                <Header className="bg-default-100 shadow-small rounded-small sticky top-1 z-20 flex w-full px-2 py-1.5 pl-3">
-                  Month
-                </Header>
-                {months.map((month, index) => {
-                  return (
-                    <ListBox.Item
-                      className="p-0"
-                      id={String(index + 1)}
-                      key={String(index + 1)}
-                      textValue={capitalize(
-                        isMobile ? month.substring(0, 3) : month
-                      )}
-                    >
-                      <Link
-                        className="flex w-full px-2.5 py-1.5 no-underline!"
-                        href={`/calendar/${calendarMode}/${focusedDate.year}/${index + 1}/1`}
-                      >
-                        {capitalize(isMobile ? month.substring(0, 3) : month)}
-                        <ListBox.ItemIndicator />
-                      </Link>
-                    </ListBox.Item>
-                  );
-                })}
-              </ListBox.Section>
-            </ListBox>
-          </Select.Popover>
-        </Select>
-        <Select
-          className="w-20"
-          variant="secondary"
-          value={yearSelectValue}
-          isOpen={yearSelectState.isOpen}
-          onOpenChange={yearSelectState.setOpen}
-        >
-          <Label className="sr-only">Year</Label>
-          <Select.Trigger>
-            <Select.Value
-              render={() => {
-                return (
-                  <span className="flex items-center gap-1">
-                    {yearSelectValue}
-                  </span>
-                );
-              }}
-            />
-            <Select.Indicator />
-          </Select.Trigger>
-          <Select.Popover className="w-25">
-            <ListBox>
-              <ListBox.Section>
-                <Header className="bg-default-100 shadow-small rounded-small sticky top-1 z-20 flex w-full px-2 py-1.5 pl-4">
-                  Year
-                </Header>
-                {YEARS.map((year) => {
-                  return (
-                    <ListBox.Item
-                      id={year.toString()}
-                      key={year.toString()}
-                      textValue={year.toString()}
-                    >
-                      <Link
-                        className="flex w-full px-2.5 py-1.5 no-underline!"
-                        href={`/calendar/${calendarMode}/${year}/${focusedDate.month}/1`}
-                      >
-                        {year.toString()}
-                        <ListBox.ItemIndicator />
-                      </Link>
-                    </ListBox.Item>
-                  );
-                })}
-              </ListBox.Section>
-            </ListBox>
-          </Select.Popover>
-        </Select>
-        {calendarMode === 'week' && (
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex items-stretch justify-between gap-2">
+        <div className="mr-0 flex items-stretch gap-2">
           <Select
             variant="secondary"
-            className="w-37.5 md:w-62.5"
-            isOpen={weekSelectState.isOpen}
-            value={selectedWeek?.key ?? null}
-            onOpenChange={weekSelectState.setOpen}
+            value={monthSelectValue}
+            className="w-17.5 md:w-28"
+            isOpen={monthSelectState.isOpen}
+            onOpenChange={monthSelectState.setOpen}
           >
-            <Label className="sr-only">Week</Label>
+            <Label className="sr-only">Month</Label>
             <Select.Trigger>
               <Select.Value
                 render={() => {
                   return (
                     <span className="flex items-center gap-1">
-                      {selectedWeek
-                        ? selectedWeek.label.split(' ').slice(0, -1).join(' ')
-                        : 'Select week'}
+                      {formatter.format(focusedDate.toDate(timeZone))}
                     </span>
                   );
                 }}
               />
               <Select.Indicator />
             </Select.Trigger>
-            <Select.Popover className="w-62.5">
+            <Select.Popover className="w-25 md:w-31.25">
               <ListBox>
                 <ListBox.Section>
-                  <Header className="bg-background shadow-small rounded-small sticky top-1 z-20 flex w-auto rounded-2xl px-2 py-1.5">
-                    Week
+                  <Header className="bg-default-100 shadow-small rounded-small sticky top-1 z-20 flex w-full px-2 py-1.5 pl-3">
+                    Month
                   </Header>
-                  {weeks.map((week) => {
+                  {months.map((month, index) => {
                     return (
                       <ListBox.Item
-                        id={week.key}
-                        key={week.key}
-                        textValue={week.label}
+                        className="p-0"
+                        id={String(index + 1)}
+                        key={String(index + 1)}
+                        textValue={capitalize(
+                          isMobile ? month.substring(0, 3) : month
+                        )}
                       >
                         <Link
                           className="flex w-full px-2.5 py-1.5 no-underline!"
-                          href={`/calendar/week/${week.anchorDate.year}/${week.anchorDate.month}/${week.anchorDate.day}`}
+                          href={`/calendar/${calendarMode}/${focusedDate.year}/${index + 1}/1`}
                         >
-                          {week.label}
+                          {capitalize(isMobile ? month.substring(0, 3) : month)}
                           <ListBox.ItemIndicator />
                         </Link>
                       </ListBox.Item>
@@ -255,28 +155,126 @@ const CalendarNavigation = ({
               </ListBox>
             </Select.Popover>
           </Select>
-        )}
-      </div>
-      <div
-        className={cn(
-          'flex gap-1 lg:gap-2',
-          calendarMode === 'week' && 'justify-center'
-        )}
-      >
-        {!isDesktop && !!user && (
-          <CustomButton
-            size="sm"
-            isIconOnly
-            variant="ghost"
-            aria-label="Toggle filters"
-            onPress={toggleFiltersVisibility}
-            className={cn(isMobile && 'min-w-fit p-0')}
+          <Select
+            className="w-20"
+            variant="secondary"
+            value={yearSelectValue}
+            isOpen={yearSelectState.isOpen}
+            onOpenChange={yearSelectState.setOpen}
           >
-            <FunnelSimpleIcon size={20} />
-          </CustomButton>
-        )}
-        <CalendarNavigationButtons focusedDate={focusedDate} />
+            <Label className="sr-only">Year</Label>
+            <Select.Trigger>
+              <Select.Value
+                render={() => {
+                  return (
+                    <span className="flex items-center gap-1">
+                      {yearSelectValue}
+                    </span>
+                  );
+                }}
+              />
+              <Select.Indicator />
+            </Select.Trigger>
+            <Select.Popover className="w-25">
+              <ListBox>
+                <ListBox.Section>
+                  <Header className="bg-default-100 shadow-small rounded-small sticky top-1 z-20 flex w-full px-2 py-1.5 pl-4">
+                    Year
+                  </Header>
+                  {YEARS.map((year) => {
+                    return (
+                      <ListBox.Item
+                        id={year.toString()}
+                        key={year.toString()}
+                        textValue={year.toString()}
+                      >
+                        <Link
+                          className="flex w-full px-2.5 py-1.5 no-underline!"
+                          href={`/calendar/${calendarMode}/${year}/${focusedDate.month}/1`}
+                        >
+                          {year.toString()}
+                          <ListBox.ItemIndicator />
+                        </Link>
+                      </ListBox.Item>
+                    );
+                  })}
+                </ListBox.Section>
+              </ListBox>
+            </Select.Popover>
+          </Select>
+        </div>
+        <div
+          className={cn(
+            'flex gap-1 lg:gap-2',
+            calendarMode === 'week' && 'justify-center'
+          )}
+        >
+          {!isDesktop && !!user && (
+            <CustomButton
+              size="sm"
+              isIconOnly
+              variant="ghost"
+              aria-label="Toggle filters"
+              onPress={toggleFiltersVisibility}
+              className={cn(isMobile && 'min-w-fit p-0')}
+            >
+              <FunnelSimpleIcon size={20} />
+            </CustomButton>
+          )}
+          <CalendarNavigationButtons focusedDate={focusedDate} />
+        </div>
       </div>
+      {calendarMode === 'week' && (
+        <Select
+          variant="secondary"
+          className="md:w-62.5"
+          isOpen={weekSelectState.isOpen}
+          value={selectedWeek?.key ?? null}
+          onOpenChange={weekSelectState.setOpen}
+        >
+          <Label className="sr-only">Week</Label>
+          <Select.Trigger>
+            <Select.Value
+              render={() => {
+                return (
+                  <span className="flex items-center gap-1">
+                    {selectedWeek
+                      ? selectedWeek.label.split(' ').slice(0, -1).join(' ')
+                      : 'Select week'}
+                  </span>
+                );
+              }}
+            />
+            <Select.Indicator />
+          </Select.Trigger>
+          <Select.Popover className="w-62.5">
+            <ListBox>
+              <ListBox.Section>
+                <Header className="bg-background shadow-small rounded-small sticky top-1 z-20 flex w-auto rounded-2xl px-2 py-1.5">
+                  Week
+                </Header>
+                {weeks.map((week) => {
+                  return (
+                    <ListBox.Item
+                      id={week.key}
+                      key={week.key}
+                      textValue={week.label}
+                    >
+                      <Link
+                        className="flex w-full px-2.5 py-1.5 no-underline!"
+                        href={`/calendar/week/${week.anchorDate.year}/${week.anchorDate.month}/${week.anchorDate.day}`}
+                      >
+                        {week.label}
+                        <ListBox.ItemIndicator />
+                      </Link>
+                    </ListBox.Item>
+                  );
+                })}
+              </ListBox.Section>
+            </ListBox>
+          </Select.Popover>
+        </Select>
+      )}
     </div>
   );
 };

--- a/src/components/calendar/CalendarNavigationButtons.tsx
+++ b/src/components/calendar/CalendarNavigationButtons.tsx
@@ -18,7 +18,7 @@ import { useNavigate, useLocation } from 'react-router';
 import type { CalendarState } from 'react-stately';
 
 import { CustomButton } from '@components';
-import { useFirstDayOfWeek, useKeyboardShortcut } from '@hooks';
+import { useScreenWidth, useFirstDayOfWeek, useKeyboardShortcut } from '@hooks';
 import { useNoteDrawerState, useOccurrenceDrawerState } from '@stores';
 
 type CalendarNavigationButtonsProps = {
@@ -35,6 +35,7 @@ const CalendarNavigationButtons = ({
   const occurrenceDrawerState = useOccurrenceDrawerState();
   const noteDrawerState = useNoteDrawerState();
   const firstDayOfWeek = useFirstDayOfWeek();
+  const { isDesktop } = useScreenWidth();
 
   const calendarMode = React.useMemo(() => {
     const pathSegments = location.pathname.split('/').filter(Boolean);
@@ -130,6 +131,7 @@ const CalendarNavigationButtons = ({
         className="px-3"
         variant="tertiary"
         href={previousRangePath}
+        size={isDesktop ? 'md' : 'sm'}
         aria-label={`Previous ${calendarMode}`}
       >
         <ArrowFatLeftIcon size={20} />
@@ -139,6 +141,7 @@ const CalendarNavigationButtons = ({
           className="px-3"
           variant="tertiary"
           href={todayRangePath}
+          size={isDesktop ? 'md' : 'sm'}
           aria-label={`Current ${calendarMode}`}
         >
           <ArrowsClockwiseIcon size={20} />
@@ -148,6 +151,7 @@ const CalendarNavigationButtons = ({
         className="px-3"
         variant="tertiary"
         href={nextRangePath}
+        size={isDesktop ? 'md' : 'sm'}
         aria-label={`Next ${calendarMode}`}
       >
         <ArrowFatRightIcon size={20} />

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -232,35 +232,51 @@ const WeekCalendar = () => {
     dayFormatter,
   ]);
 
+  const calendarControls = (
+    <>
+      <Tooltip closeDelay={0}>
+        <Tooltip.Trigger>
+          <CustomButton
+            variant="tertiary"
+            href={monthInfo.path}
+            size={isDesktop ? 'md' : 'sm'}
+            aria-label={`Go to month view: ${monthInfo.label}`}
+          >
+            <ArrowSquareLeftIcon weight="bold" />
+            <span>{monthInfo.label}</span>
+          </CustomButton>
+        </Tooltip.Trigger>
+        <Tooltip.Content>
+          Go to the month view of {monthInfo.label}
+        </Tooltip.Content>
+      </Tooltip>
+      <div className="flex flex-col items-center justify-center gap-2">
+        <CalendarNavigation focusedDate={state.focusedDate} />
+      </div>
+      <div className="w-10/12 md:w-auto">
+        <CalendarFilters />
+      </div>
+    </>
+  );
+
   return (
-    <div className="flex w-full flex-1 gap-0 md:gap-6">
+    <div className="flex w-full flex-1 flex-col gap-0 md:gap-6 lg:flex-row-reverse">
+      <aside className="flex shrink-0 flex-col gap-2 overflow-y-auto pt-4 pb-2 lg:w-86">
+        {isDesktop && calendarControls}
+        <CalendarPeriodSummary
+          kind="week"
+          note={weekNote}
+          startDate={monday}
+          metricTotals={metricTotals}
+          occurrenceSummary={occurrenceSummary}
+        />
+      </aside>
       <ScrollShadow
         orientation="horizontal"
         className="relative w-full overflow-y-scroll"
       >
-        <div className="sticky left-0 flex flex-col items-center justify-center gap-4">
-          <div className="flex items-center justify-center gap-2">
-            <Tooltip closeDelay={0}>
-              <Tooltip.Trigger>
-                <CustomButton
-                  variant="light"
-                  href={monthInfo.path}
-                  className="min-w-fit gap-2 px-2"
-                  aria-label={`Go to month view: ${monthInfo.label}`}
-                >
-                  <ArrowSquareLeftIcon weight="bold" />
-                  <span className="hidden sm:inline">{monthInfo.label}</span>
-                </CustomButton>
-              </Tooltip.Trigger>
-              <Tooltip.Content>
-                Go to the month view of {monthInfo.label}
-              </Tooltip.Content>
-            </Tooltip>
-            <CalendarNavigation focusedDate={state.focusedDate} />
-          </div>
-          <div className="w-10/12 md:w-auto">
-            <CalendarFilters />
-          </div>
+        <div className="sticky left-0 flex flex-col items-start justify-center gap-2 lg:items-center">
+          {!isDesktop && calendarControls}
         </div>
         <div
           {...gridProps}
@@ -444,15 +460,6 @@ const WeekCalendar = () => {
             })}
         </div>
       </ScrollShadow>
-      <aside className="hidden w-72 shrink-0 flex-col gap-4 overflow-y-auto pr-8 xl:flex">
-        <CalendarPeriodSummary
-          kind="week"
-          note={weekNote}
-          startDate={monday}
-          metricTotals={metricTotals}
-          occurrenceSummary={occurrenceSummary}
-        />
-      </aside>
     </div>
   );
 };

--- a/src/components/common/CustomButton.tsx
+++ b/src/components/common/CustomButton.tsx
@@ -74,7 +74,7 @@ const CustomButton = (props: CustomButtonProps) => {
     return (
       <Link
         {...linkProps}
-        className={className}
+        className={cn('gap-2', className)}
         onPointerDown={(event) => {
           createRipple(event);
           linkProps.onPointerDown?.(event);

--- a/src/pages/WeekCalendarPage.tsx
+++ b/src/pages/WeekCalendarPage.tsx
@@ -4,7 +4,7 @@ import { WeekCalendar } from '@components';
 
 const WeekCalendarPage = () => {
   return (
-    <div className="relative my-4 flex h-full w-full max-w-full flex-1 flex-col space-y-8 md:my-8">
+    <div className="relative flex h-full w-full max-w-full flex-1 flex-col gap-2 p-0 px-4 pb-8 md:gap-3 md:py-3 lg:px-16">
       <WeekCalendar />
     </div>
   );


### PR DESCRIPTION
## Description

Rework calendar navigation and week view layout for improved responsiveness and clarity. Changes include:

- CalendarNavigation: remove unused className prop, reorganize month/year/week Selects into a stacked, responsive layout; move the week selector into a dedicated area when in week mode and adjust Select popover widths/headers and item links.
- CalendarNavigationButtons: useScreenWidth added to adjust button sizes between desktop and mobile.
- WeekCalendar: extract a calendarControls fragment (month back button, navigation, filters), move controls into an aside on desktop and render them above the grid on mobile; change overall container to support column / reversed row layout and remove duplicate Sidebar summary.
- CustomButton: always include a default gap class ('gap-2') when rendering link buttons.
- WeekCalendarPage: adjust page container spacing and padding.

These updates improve responsive behavior and unify control placement across breakpoints.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized calendar navigation layout into a two-row structure for improved responsive design
  * Repositioned calendar controls (filters, navigation buttons, week selector) for better mobile and desktop experiences

* **Style**
  * Navigation buttons now adapt size dynamically based on screen width
  * Refined spacing and padding throughout the calendar interface for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->