### PR TITLE
feat(calendar): add drawer-aware highlighting to month cells

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ const App = () => {
       <main className="bg-background-50 dark:bg-background-700 flex h-full flex-1 items-center justify-center">
         <div className="flex flex-row items-center gap-4">
           <InfinityLoader color="var(--accent)" />
-          <span>Loading your session...</span>
+          <span>We're preparing the app...</span>
         </div>
       </main>
     );

--- a/src/components/calendar/CalendarNavigation.tsx
+++ b/src/components/calendar/CalendarNavigation.tsx
@@ -45,7 +45,7 @@ const CalendarNavigation = ({ focusedDate }: MonthCalendarNavigationProps) => {
     null
   );
   const formatter = useDateFormatter({
-    month: 'long',
+    month: isDesktop ? 'long' : 'short',
   });
   const months = React.useMemo(() => {
     return [
@@ -118,7 +118,9 @@ const CalendarNavigation = ({ focusedDate }: MonthCalendarNavigationProps) => {
                 render={() => {
                   return (
                     <span className="flex items-center gap-1">
-                      {formatter.format(focusedDate.toDate(timeZone))}
+                      {capitalize(
+                        formatter.format(focusedDate.toDate(timeZone))
+                      )}
                     </span>
                   );
                 }}
@@ -137,15 +139,13 @@ const CalendarNavigation = ({ focusedDate }: MonthCalendarNavigationProps) => {
                         className="p-0"
                         id={String(index + 1)}
                         key={String(index + 1)}
-                        textValue={capitalize(
-                          isMobile ? month.substring(0, 3) : month
-                        )}
+                        textValue={capitalize(month)}
                       >
                         <Link
                           className="flex w-full px-2.5 py-1.5 no-underline!"
                           href={`/calendar/${calendarMode}/${focusedDate.year}/${index + 1}/1`}
                         >
-                          {capitalize(isMobile ? month.substring(0, 3) : month)}
+                          {capitalize(month)}
                           <ListBox.ItemIndicator />
                         </Link>
                       </ListBox.Item>

--- a/src/components/calendar/CalendarPeriodSummary.tsx
+++ b/src/components/calendar/CalendarPeriodSummary.tsx
@@ -116,7 +116,6 @@ const CalendarPeriodSummary = ({
       {!note && startDate && (
         <CustomButton
           fullWidth
-          size="sm"
           variant="secondary"
           onPress={() => {
             openNoteDrawer(startDate, kind);

--- a/src/components/calendar/DayCalendar.tsx
+++ b/src/components/calendar/DayCalendar.tsx
@@ -12,8 +12,8 @@ import {
 import {
   NoteIcon,
   NoteBlankIcon,
+  ArrowsOutIcon,
   CalendarBlankIcon,
-  ArrowSquareLeftIcon,
 } from '@phosphor-icons/react';
 import groupBy from 'lodash.groupby';
 import React from 'react';
@@ -210,7 +210,7 @@ const DayCalendar = () => {
                   className="min-w-fit gap-2 px-2"
                   aria-label={`Go to week view: ${weekInfo.label}`}
                 >
-                  <ArrowSquareLeftIcon weight="bold" className="h-5 w-5" />
+                  <ArrowsOutIcon weight="bold" className="h-5 w-5" />
                   <span className="hidden sm:inline">{weekInfo.label}</span>
                 </CustomButton>
               </Tooltip.Trigger>

--- a/src/components/calendar/MonthCalendarCell.tsx
+++ b/src/components/calendar/MonthCalendarCell.tsx
@@ -1,6 +1,6 @@
 import { cn, Popover, Tooltip } from '@heroui/react';
 import type { CalendarDate } from '@internationalized/date';
-import { isToday } from '@internationalized/date';
+import { isToday, isEqualDay } from '@internationalized/date';
 import {
   NoteIcon,
   NoteBlankIcon,
@@ -21,6 +21,7 @@ import {
   useUser,
   useDayNotes,
   useNoteDrawerActions,
+  useOccurrenceDrawerState,
   useOccurrenceDrawerActions,
 } from '@stores';
 
@@ -47,6 +48,12 @@ const MonthCalendarCell = ({
   const user = useUser();
   const dayNotes = useDayNotes();
   const { openNoteDrawer } = useNoteDrawerActions();
+  const {
+    dayToDisplay,
+    dayToLog,
+    isOpen: isOccurrenceDrawerOpen,
+    occurrenceToEdit,
+  } = useOccurrenceDrawerState();
   const { openOccurrenceDrawer } = useOccurrenceDrawerActions();
   const { isDesktop, isMobile, screenWidth } = useScreenWidth();
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
@@ -85,21 +92,16 @@ const MonthCalendarCell = ({
     }
   );
 
-  const cellRootClassName = cn(
-    'group/cell flex h-auto flex-1 flex-col gap-2 border-r-2 border-neutral-500 transition-colors last-of-type:border-r-0 hover:bg-neutral-200 focus:border-neutral-100 dark:border-neutral-400 dark:hover:bg-neutral-800 lg:h-36',
-    position === 'top-left' && 'rounded-tl-3xl',
-    position === 'top-right' && 'rounded-tr-3xl',
-    position === 'bottom-left' && 'rounded-bl-3xl',
-    position === 'bottom-right' && 'rounded-br-3xl',
-    isTodayCell &&
-      'bg-background-100 hover:bg-background-300 dark:bg-background-500 dark:hover:bg-background-300'
-  );
+  const drawerDate = occurrenceToEdit?.occurredAt || dayToLog || dayToDisplay;
+  const isDrawerDate =
+    drawerDate && isOccurrenceDrawerOpen && isEqualDay(drawerDate, date);
 
   const cellHeaderClassName = cn(
     'flex w-full items-center justify-between border-b border-neutral-500 pl-1.5 pr-0.5 py-0.5 text-sm dark:border-neutral-400',
     isOutsideVisibleRange && 'text-neutral-400 dark:text-neutral-600',
     isTodayCell ? 'w-full self-auto md:self-start' : 'w-full',
-    isMobile && 'pl-1'
+    isMobile && 'pl-1',
+    isDrawerDate && 'border-backdrop dark:border-neutral-400/40'
   );
 
   const openLoggingDrawer = () => {
@@ -114,60 +116,76 @@ const MonthCalendarCell = ({
 
   const cellHeader = (
     <div className={cellHeaderClassName}>
-      <p className={cn('font-bold', isMobile && 'text-sm')}>{formattedDate}</p>
-      <div className="flex items-center justify-between gap-2">
+      <p
+        className={cn(
+          'font-bold',
+          isMobile && 'text-sm hover:bg-neutral-200 dark:hover:bg-neutral-800'
+        )}
+      >
+        {formattedDate}
+      </p>
+      <div className="flex items-center justify-between gap-2 pr-2">
         {isMobile && screenWidth > 360 && hasNote && (
           <NoteIcon size={12} weight="bold" />
         )}
         {isDesktop && (
           <div className="flex items-center gap-1">
-            <Tooltip closeDelay={0}>
-              <Tooltip.Trigger>
+            <Tooltip delay={0} closeDelay={0}>
+              <Tooltip.Trigger className="flex">
                 <CustomButton
                   variant="light"
                   aria-label="Open day"
                   href={`/calendar/day/${date.year}/${date.month}/${date.day}`}
-                  className="h-5 w-5 min-w-fit rounded-xl px-0 opacity-0 group-hover/cell:opacity-100 focus:opacity-100 lg:h-6 lg:w-6"
+                  className={cn(
+                    'h-5 w-5 min-w-fit rounded-xl px-0 opacity-0 group-hover/cell:opacity-100 focus:opacity-100 lg:h-6 lg:w-6',
+                    (isTodayCell || isDrawerDate) && 'opacity-100'
+                  )}
                 >
                   <ArrowSquareRightIcon size={18} weight="bold" />
                 </CustomButton>
               </Tooltip.Trigger>
               <Tooltip.Content>Open day</Tooltip.Content>
             </Tooltip>
-            <Tooltip closeDelay={0}>
-              <Tooltip.Trigger>
+            <Tooltip delay={0} closeDelay={0}>
+              <Tooltip.Trigger className="flex">
                 <CustomButton
                   variant="light"
                   isDisabled={!user}
                   aria-label="Show habit log"
-                  className="h-5 w-5 min-w-fit rounded-xl px-0 opacity-0 group-hover/cell:opacity-100 focus:opacity-100 lg:h-6 lg:w-6"
                   onPress={() => {
                     openOccurrenceDrawer({
                       dayToDisplay: date,
                     });
                   }}
+                  className={cn(
+                    'h-5 w-5 min-w-fit rounded-xl px-0 opacity-0 group-hover/cell:opacity-100 focus:opacity-100 lg:h-6 lg:w-6',
+                    (isTodayCell || isDrawerDate) && 'opacity-100'
+                  )}
                 >
                   <SquareHalfIcon size={18} weight="bold" />
                 </CustomButton>
               </Tooltip.Trigger>
               <Tooltip.Content>Show habit log</Tooltip.Content>
             </Tooltip>
-            <Tooltip closeDelay={0}>
-              <Tooltip.Trigger>
+            <Tooltip delay={0} closeDelay={0}>
+              <Tooltip.Trigger className="flex">
                 <CustomButton
                   variant="light"
                   isDisabled={!user}
                   aria-label="Log habit"
                   onPress={openLoggingDrawer}
-                  className="h-5 w-5 min-w-fit rounded-xl px-0 opacity-0 group-hover/cell:opacity-100 focus:opacity-100 lg:h-6 lg:w-6"
+                  className={cn(
+                    'h-5 w-5 min-w-fit rounded-xl px-0 opacity-0 group-hover/cell:opacity-100 focus:opacity-100 lg:h-6 lg:w-6',
+                    (isTodayCell || isDrawerDate) && 'opacity-100'
+                  )}
                 >
                   <CalendarPlusIcon size={18} weight="bold" />
                 </CustomButton>
               </Tooltip.Trigger>
               <Tooltip.Content>Log habit</Tooltip.Content>
             </Tooltip>
-            <Tooltip closeDelay={0}>
-              <Tooltip.Trigger>
+            <Tooltip delay={0} closeDelay={0}>
+              <Tooltip.Trigger className="flex">
                 <CustomButton
                   variant="light"
                   isDisabled={!user}
@@ -177,6 +195,7 @@ const MonthCalendarCell = ({
                   }}
                   className={cn(
                     'h-5 w-5 min-w-fit rounded-xl px-0 opacity-0 group-hover/cell:opacity-100 focus:opacity-100 lg:h-6 lg:w-6',
+                    (isTodayCell || isDrawerDate) && 'opacity-100',
                     hasNote && 'text-accent opacity-100'
                   )}
                 >
@@ -194,91 +213,113 @@ const MonthCalendarCell = ({
           </div>
         )}
         {isTodayCell && !isMobile && (
-          <CalendarBlankIcon weight="fill" size={isMobile ? 18 : 20} />
+          <CalendarBlankIcon size={16} weight="fill" />
         )}
       </div>
     </div>
   );
 
   return (
-    <div ref={calendarCellRef} {...cellProps} className={cellRootClassName}>
-      {!isDesktop && user ? (
-        <Popover isOpen={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
-          <Popover.Trigger>{cellHeader}</Popover.Trigger>
-          <Popover.Content offset={12} placement="bottom">
-            <Popover.Dialog className="p-0">
-              <Popover.Arrow />
-              <div className="flex flex-col gap-1 p-1">
-                <CustomButton
-                  size="sm"
-                  variant="ghost"
-                  className="justify-start gap-2"
-                  href={`/calendar/day/${date.year}/${date.month}/${date.day}`}
-                >
-                  <ArrowSquareRightIcon size={16} weight="bold" />
-                  Open day
-                </CustomButton>
-                <CustomButton
-                  size="sm"
-                  variant="ghost"
-                  className="justify-start"
-                  onPress={() => {
-                    setIsPopoverOpen(false);
-                    openOccurrenceDrawer({
-                      dayToDisplay: date,
-                    });
-                  }}
-                >
-                  <SquareHalfIcon size={16} weight="bold" />
-                  Show habit log
-                </CustomButton>
-                <CustomButton
-                  size="sm"
-                  variant="ghost"
-                  className="justify-start"
-                  onPress={() => {
-                    setIsPopoverOpen(false);
-                    openLoggingDrawer();
-                  }}
-                >
-                  <CalendarPlusIcon size={16} weight="bold" />
-                  Log habit
-                </CustomButton>
-                <CustomButton
-                  size="sm"
-                  variant="ghost"
-                  className={cn('justify-start', hasNote && 'text-accent')}
-                  onPress={() => {
-                    setIsPopoverOpen(false);
-                    openNoteDrawer(date, 'day');
-                  }}
-                >
-                  {hasNote ? (
-                    <NoteIcon size={16} weight="bold" />
-                  ) : (
-                    <NoteBlankIcon size={16} weight="bold" />
-                  )}
-                  {hasNote ? 'Edit note' : 'Add note'}
-                </CustomButton>
-              </div>
-            </Popover.Dialog>
-          </Popover.Content>
-        </Popover>
-      ) : (
-        cellHeader
-      )}
-      <div className="flex flex-wrap justify-center gap-2 overflow-x-auto overflow-y-visible px-0 py-0.5 pb-2 md:justify-start md:px-2">
-        {Object.entries(groupedOccurrences).map(
-          ([habitId, habitOccurrences]) => {
-            if (!habitOccurrences) {
-              return null;
-            }
-
-            return (
-              <OccurrenceChip key={habitId} occurrences={habitOccurrences} />
-            );
-          }
+    <div
+      ref={calendarCellRef}
+      {...cellProps}
+      className="group/cell flex h-auto flex-1 flex-col gap-2 border-r-2 border-neutral-500 last-of-type:border-r-0 focus:border-neutral-100 lg:h-36 dark:border-neutral-400"
+    >
+      <div
+        className={cn(
+          'bg-background-50 hover:bg-background-200 dark:bg-background-800 dark:hover:bg-background-900 relative flex-1 space-y-2 transition-colors',
+          isTodayCell &&
+            'bg-background-100 hover:bg-background-300 dark:bg-background-600 dark:hover:bg-background-500',
+          isDrawerDate &&
+            isTodayCell &&
+            'bg-background-300 dark:bg-background-500 z-51',
+          isDrawerDate &&
+            !isTodayCell &&
+            'bg-background-200 dark:bg-background-900 z-51',
+          position === 'top-left' && 'rounded-tl-3xl',
+          position === 'top-right' && 'rounded-tr-3xl',
+          position === 'bottom-left' && 'rounded-bl-3xl',
+          position === 'bottom-right' && 'rounded-br-3xl'
         )}
+      >
+        {!isDesktop && user ? (
+          <Popover isOpen={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+            <Popover.Trigger>{cellHeader}</Popover.Trigger>
+            <Popover.Content offset={12} placement="bottom">
+              <Popover.Dialog className="p-0">
+                <Popover.Arrow />
+                <div className="flex flex-col gap-1 p-1">
+                  <CustomButton
+                    size="sm"
+                    variant="ghost"
+                    className="justify-start gap-2"
+                    href={`/calendar/day/${date.year}/${date.month}/${date.day}`}
+                  >
+                    <ArrowSquareRightIcon size={16} weight="bold" />
+                    Open day
+                  </CustomButton>
+                  <CustomButton
+                    size="sm"
+                    variant="ghost"
+                    className="justify-start"
+                    onPress={() => {
+                      setIsPopoverOpen(false);
+                      openOccurrenceDrawer({
+                        dayToDisplay: date,
+                      });
+                    }}
+                  >
+                    <SquareHalfIcon size={16} weight="bold" />
+                    Show habit log
+                  </CustomButton>
+                  <CustomButton
+                    size="sm"
+                    variant="ghost"
+                    className="justify-start"
+                    onPress={() => {
+                      setIsPopoverOpen(false);
+                      openLoggingDrawer();
+                    }}
+                  >
+                    <CalendarPlusIcon size={16} weight="bold" />
+                    Log habit
+                  </CustomButton>
+                  <CustomButton
+                    size="sm"
+                    variant="ghost"
+                    className={cn('justify-start', hasNote && 'text-accent')}
+                    onPress={() => {
+                      setIsPopoverOpen(false);
+                      openNoteDrawer(date, 'day');
+                    }}
+                  >
+                    {hasNote ? (
+                      <NoteIcon size={16} weight="bold" />
+                    ) : (
+                      <NoteBlankIcon size={16} weight="bold" />
+                    )}
+                    {hasNote ? 'Edit note' : 'Add note'}
+                  </CustomButton>
+                </div>
+              </Popover.Dialog>
+            </Popover.Content>
+          </Popover>
+        ) : (
+          cellHeader
+        )}
+        <div className="flex flex-wrap justify-center gap-2 overflow-x-auto overflow-y-visible px-0 py-0.5 pb-2 md:justify-start md:px-2">
+          {Object.entries(groupedOccurrences).map(
+            ([habitId, habitOccurrences]) => {
+              if (!habitOccurrences) {
+                return null;
+              }
+
+              return (
+                <OccurrenceChip key={habitId} occurrences={habitOccurrences} />
+              );
+            }
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/calendar/WeekCalendar.tsx
+++ b/src/components/calendar/WeekCalendar.tsx
@@ -1,4 +1,4 @@
-import { cn, Tooltip, ScrollShadow } from '@heroui/react';
+import { cn, Tooltip, Accordion, ScrollShadow } from '@heroui/react';
 import {
   today,
   isToday,
@@ -13,8 +13,9 @@ import {
 import {
   NoteIcon,
   NoteBlankIcon,
+  ArrowsOutIcon,
+  CaretDownIcon,
   CalendarBlankIcon,
-  ArrowSquareLeftIcon,
   ArrowSquareRightIcon,
 } from '@phosphor-icons/react';
 import capitalize from 'lodash.capitalize';
@@ -220,7 +221,7 @@ const WeekCalendar = () => {
     const rangeEnd = dayFormatter.format(monthEnd.toDate(timeZone));
 
     return {
-      label: `${monthName}: ${rangeStart} – ${rangeEnd}`,
+      label: `${capitalize(monthName)}: ${rangeStart} – ${rangeEnd}`,
       path: `/calendar/month/${thursday.year}/${thursday.month}/1`,
     };
   }, [
@@ -242,7 +243,7 @@ const WeekCalendar = () => {
             size={isDesktop ? 'md' : 'sm'}
             aria-label={`Go to month view: ${monthInfo.label}`}
           >
-            <ArrowSquareLeftIcon weight="bold" />
+            <ArrowsOutIcon weight="bold" />
             <span>{monthInfo.label}</span>
           </CustomButton>
         </Tooltip.Trigger>
@@ -261,12 +262,13 @@ const WeekCalendar = () => {
 
   return (
     <div className="flex w-full flex-1 flex-col gap-0 md:gap-6 lg:flex-row-reverse">
-      <aside className="flex shrink-0 flex-col gap-2 overflow-y-auto pt-4 pb-2 lg:w-86">
-        {isDesktop && calendarControls}
+      <aside className="flex shrink-0 flex-col gap-2 overflow-y-auto pt-4 pb-2 max-lg:hidden max-lg:px-8 lg:w-86">
+        {calendarControls}
         <CalendarPeriodSummary
           kind="week"
           note={weekNote}
           startDate={monday}
+          className="max-lg:pb-2"
           metricTotals={metricTotals}
           occurrenceSummary={occurrenceSummary}
         />
@@ -275,12 +277,34 @@ const WeekCalendar = () => {
         orientation="horizontal"
         className="relative w-full overflow-y-scroll"
       >
-        <div className="sticky left-0 flex flex-col items-start justify-center gap-2 lg:items-center">
-          {!isDesktop && calendarControls}
+        <div className="sticky left-0 flex flex-col items-start justify-center gap-2 px-8 pt-2 lg:hidden lg:items-center">
+          <Accordion>
+            <Accordion.Item key="summary">
+              <Accordion.Heading>
+                <Accordion.Trigger className="bg-default flex w-full items-center gap-2 rounded-3xl py-2">
+                  Summary
+                  <Accordion.Indicator>
+                    <CaretDownIcon />
+                  </Accordion.Indicator>
+                </Accordion.Trigger>
+              </Accordion.Heading>
+              <Accordion.Panel>
+                <CalendarPeriodSummary
+                  kind="week"
+                  note={weekNote}
+                  className="pt-2"
+                  startDate={monday}
+                  metricTotals={metricTotals}
+                  occurrenceSummary={occurrenceSummary}
+                />
+              </Accordion.Panel>
+            </Accordion.Item>
+          </Accordion>
+          {calendarControls}
         </div>
         <div
           {...gridProps}
-          className="flex min-w-lg justify-around px-8 py-4 lg:px-16 xl:pr-2"
+          className="flex min-w-lg justify-around py-4 max-lg:px-8 xl:pr-2"
         >
           {state
             .getDatesInWeek(firstDayOfWeek === 'sun' ? 0 : 1)


### PR DESCRIPTION
## Description

Multiple calendar-related UI and behavior updates: update app loading text; make month labels use short format on smaller screens and ensure capitalization in navigation; remove an unnecessary size prop from CalendarPeriodSummary buttons; swap several icons (use ArrowsOutIcon in day/week views) and tweak tooltip/button behaviors for consistent visibility when a day or drawer is active. MonthCalendarCell was reworked to integrate occurrence-drawer state (useOccurrenceDrawerState), add drawer-aware highlighting, adjust layout and styles, simplify popover content, and ensure action buttons show when relevant. WeekCalendar adds a mobile Accordion for the summary, capitalizes month labels, and adjusts responsive layout/padding.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed
