### PR TITLE
feat(calendar): add border beam to drawer cell

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,36 +1,27 @@
-import { defineConfig, globalIgnores } from 'eslint/config';
-
-import globals from 'globals';
 import js from '@eslint/js';
 import stylistic from '@stylistic/eslint-plugin';
-import tsEslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier/flat';
 import perfectionist from 'eslint-plugin-perfectionist';
 import reactHooks from 'eslint-plugin-react-hooks';
 import switchCase from 'eslint-plugin-switch-case';
 import unusedImports from 'eslint-plugin-unused-imports';
-import eslintConfigPrettier from 'eslint-config-prettier/flat';
+import { defineConfig, globalIgnores } from 'eslint/config';
+import globals from 'globals';
+import tsEslint from 'typescript-eslint';
 
 const plugins = {
-  'react-hooks': reactHooks,
   '@stylistic': stylistic,
   js,
   perfectionist,
+  'react-hooks': reactHooks,
   'switch-case': switchCase,
   'unused-imports': unusedImports,
 };
 
-const rules = {
+const typescriptRules = {
   '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
   '@typescript-eslint/consistent-type-imports': 'error',
   '@typescript-eslint/no-deprecated': 'error',
-  'arrow-body-style': ['error', 'always'],
-  curly: 'error',
-  'no-undef': 'off',
-  'no-useless-rename': 'error',
-  'object-shorthand': 'error',
-  'switch-case/no-case-curly': 'off',
-  'unused-imports/no-unused-imports': 'error',
-
   '@typescript-eslint/no-unused-vars': [
     'error',
     {
@@ -38,6 +29,23 @@ const rules = {
       ignoreRestSiblings: true,
       varsIgnorePattern: '^_',
     },
+  ],
+};
+
+const javascriptRules = {
+  'arrow-body-style': ['error', 'always'],
+  curly: 'error',
+  'no-undef': 'off',
+  'no-useless-rename': 'error',
+  'object-shorthand': 'error',
+  'react-hooks/exhaustive-deps': 'error',
+  'switch-case/no-case-curly': 'off',
+
+  'unused-imports/no-unused-imports': 'error',
+
+  '@stylistic/jsx-curly-brace-presence': [
+    'error',
+    { children: 'never', propElementValues: 'always', props: 'never' },
   ],
 
   'no-console': [
@@ -115,8 +123,6 @@ const rules = {
     },
   ],
 
-  'react-hooks/exhaustive-deps': 'error',
-
   'switch-case/newline-between-switch-case': [
     'error',
     'always',
@@ -128,28 +134,33 @@ export default defineConfig(
   [
     globalIgnores(['**/dist/', 'tests/coverage', '.yarn/releases']),
     {
+      files: ['*.ts', 'src/**/*.{ts,tsx}', 'tests/*.ts'],
+      plugins,
       extends: [
         js.configs.recommended,
         tsEslint.configs.recommended,
         switchCase.configs.recommended,
       ],
-      files: ['*.{ts}', 'src/**/*.{ts,tsx}', 'tests/*.ts'],
       languageOptions: {
         parserOptions: {
           projectService: true,
           tsconfigRootDir: import.meta.dirname,
         },
       },
-      plugins,
-      rules,
+      rules: {
+        ...typescriptRules,
+        ...javascriptRules,
+      },
     },
     {
+      files: ['*.js', 'scripts/*.js'],
+      plugins,
+      rules: javascriptRules,
       extends: [
         js.configs.recommended,
         tsEslint.configs.recommended,
         switchCase.configs.recommended,
       ],
-      files: ['*.{js}', 'scripts/*.js'],
       languageOptions: {
         globals: {
           ...globals.node,

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@rollbar/react": "^1.0.0",
     "@supabase/supabase-js": "^2.108.2",
     "@vercel/analytics": "^2.0.1",
+    "border-beam": "^1.3.0",
     "browser-image-compression": "^2.0.2",
     "camelcase-keys": "^10.0.2",
     "decamelize-keys": "^2.0.1",

--- a/src/components/calendar/MonthCalendarCell.tsx
+++ b/src/components/calendar/MonthCalendarCell.tsx
@@ -8,17 +8,20 @@ import {
   CalendarPlusIcon,
   ArrowSquareRightIcon,
 } from '@phosphor-icons/react';
+import type { BorderBeamProps } from 'border-beam';
+import BorderBeam from 'border-beam';
 import groupBy from 'lodash.groupby';
 import React from 'react';
 import { useCalendarCell } from 'react-aria';
 import type { CalendarState } from 'react-stately';
 
 import { CustomButton, OccurrenceChip } from '@components';
-import { useScreenWidth } from '@hooks';
+import { useThemeMode, useScreenWidth } from '@hooks';
 import type { Occurrence } from '@models';
 import {
   useUser,
   useDayNotes,
+  useNoteDrawerState,
   useNoteDrawerActions,
   useOccurrenceDrawerState,
   useOccurrenceDrawerActions,
@@ -53,6 +56,11 @@ const MonthCalendarCell = ({
     isOpen: isOccurrenceDrawerOpen,
     occurrenceToEdit,
   } = useOccurrenceDrawerState();
+  const {
+    isOpen: isNoteDrawerOpen,
+    periodDate: noteDrawerPeriodDate,
+    periodKind: noteDrawerPeriodKind,
+  } = useNoteDrawerState();
   const { openOccurrenceDrawer } = useOccurrenceDrawerActions();
   const { isDesktop, isMobile, screenWidth } = useScreenWidth();
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
@@ -62,6 +70,7 @@ const MonthCalendarCell = ({
     state,
     calendarCellRef
   );
+  const { themeMode } = useThemeMode();
 
   const isTodayCell = isToday(date, state.timeZone);
 
@@ -91,9 +100,15 @@ const MonthCalendarCell = ({
     }
   );
 
-  const drawerDate = occurrenceToEdit?.occurredAt || dayToLog || dayToDisplay;
+  const occurrenceDrawerDate =
+    occurrenceToEdit?.occurredAt || dayToLog || dayToDisplay;
   const isDrawerDate =
-    drawerDate && isOccurrenceDrawerOpen && isEqualDay(drawerDate, date);
+    (occurrenceDrawerDate &&
+      isOccurrenceDrawerOpen &&
+      isEqualDay(occurrenceDrawerDate, date)) ||
+    (isNoteDrawerOpen &&
+      noteDrawerPeriodKind === 'day' &&
+      isEqualDay(noteDrawerPeriodDate, date));
 
   const openLoggingDrawer = () => {
     if (!user) {
@@ -115,11 +130,11 @@ const MonthCalendarCell = ({
         isDrawerDate &&
           isDesktop &&
           !isTodayCell &&
-          'bg-background dark:bg-surface z-51',
+          'bg-background dark:bg-surface',
         isDrawerDate &&
           isDesktop &&
           isTodayCell &&
-          'bg-background-secondary dark:bg-surface-secondary z-51',
+          'bg-background-secondary dark:bg-surface-secondary',
         isOutsideVisibleRange && 'text-neutral-400 dark:text-neutral-600',
         isTodayCell ? 'w-full self-auto md:self-start' : 'w-full',
         isMobile && 'pl-1'
@@ -226,13 +241,24 @@ const MonthCalendarCell = ({
     </div>
   );
 
+  const Component = isDrawerDate ? BorderBeam : 'div';
+
+  const borderBeamProps: Omit<BorderBeamProps, 'children'> = {
+    active: isDrawerDate,
+    borderRadius: 0,
+    size: 'pulse-inner',
+    strength: 0.6,
+    theme: themeMode === 'system' ? 'auto' : themeMode,
+  };
+
   return (
     <div
       ref={calendarCellRef}
       {...cellProps}
-      className="group/cell border-border flex h-auto flex-1 flex-col gap-2 border-r-2 last-of-type:border-r-0 lg:h-36"
+      className="group/cell border-border flex h-auto flex-1 flex-col gap-2 rounded-none border-r-2 last-of-type:border-r-0 lg:h-36"
     >
-      <div
+      <Component
+        {...(isDrawerDate && borderBeamProps)}
         className={cn(
           'group-hover/cell:bg-background dark:group-hover/cell:bg-surface relative flex-1 space-y-2 overflow-x-auto overflow-y-visible bg-white transition-colors dark:bg-black',
           isTodayCell &&
@@ -240,15 +266,15 @@ const MonthCalendarCell = ({
           isDrawerDate &&
             isDesktop &&
             isTodayCell &&
-            'bg-background-secondary dark:bg-surface-secondary z-51',
+            'bg-background-secondary dark:bg-surface-secondary z-52',
           isDrawerDate &&
             isDesktop &&
             !isTodayCell &&
-            'bg-background dark:bg-surface z-51',
-          position === 'top-left' && 'rounded-tl-3xl',
-          position === 'top-right' && 'rounded-tr-3xl',
-          position === 'bottom-left' && 'rounded-bl-3xl',
-          position === 'bottom-right' && 'rounded-br-3xl'
+            'bg-background dark:bg-surface z-52',
+          position === 'top-left' && 'rounded-tl-[10px]!',
+          position === 'top-right' && 'rounded-tr-[10px]!',
+          position === 'bottom-left' && 'rounded-bl-[10px]!',
+          position === 'bottom-right' && 'rounded-br-[10px]!'
         )}
       >
         {screenWidth < 1360 && user ? (
@@ -331,7 +357,7 @@ const MonthCalendarCell = ({
             }
           )}
         </div>
-      </div>
+      </Component>
     </div>
   );
 };

--- a/src/components/header/ThemeToggle.tsx
+++ b/src/components/header/ThemeToggle.tsx
@@ -34,7 +34,7 @@ const ThemeToggle = () => {
             <CustomButton
               size="sm"
               isIconOnly
-              variant={'outline'}
+              variant="outline"
               className={cn('md:size-8', isSelected && 'text-accent')}
               onPress={() => {
                 setThemeMode(mode);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,6 +2537,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"border-beam@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "border-beam@npm:1.3.0"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-dom: ">=18.0.0"
+  checksum: 10c0/4c252d7ced08f989e42f3ca614d23632223149a48bc8f479656b74d275c766cfa1bf3c270480dd34a7a873f1adc4d6a5a0dea67fe274edff0c612f515b06e99b
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.15
   resolution: "brace-expansion@npm:1.1.15"
@@ -3512,6 +3522,7 @@ __metadata:
     "@vercel/analytics": "npm:^2.0.1"
     "@vitejs/plugin-react": "npm:^6.0.3"
     "@vitest/coverage-v8": "npm:4.1.9"
+    border-beam: "npm:^1.3.0"
     browser-image-compression: "npm:^2.0.2"
     camelcase-keys: "npm:^10.0.2"
     decamelize-keys: "npm:^2.0.1"


### PR DESCRIPTION
## Description

When note or occurrence drawer opens, the cell which date equals to the drawer date is now highlighted with the border beam effect.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Calendar day cells now show a more prominent visual highlight when a related drawer is open, including day notes.
  - Added a refined border effect for the active calendar cell to better match the current theme.

- **Bug Fixes**
  - Improved calendar highlighting so it applies consistently across both note and occurrence drawers.

- **Style**
  - Minor theme toggle button styling cleanup for more consistent button rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->