### PR TITLE
feat(calendar): extend occurrences and notes caching by range

### DIFF
--- a/src/stores/notes.store.ts
+++ b/src/stores/notes.store.ts
@@ -5,7 +5,13 @@ import { useShallow } from 'zustand/react/shallow';
 
 import type { Note, Occurrence, NotesInsert, NotesUpdate } from '@models';
 import { listNotes, createNote, updateNote, destroyNote } from '@services';
-import { isNoteOfPeriod, isNoteOfOccurrence } from '@utils';
+import {
+  isNoteOfPeriod,
+  type CalendarRange,
+  isNoteOfOccurrence,
+  createCalendarRangeCache,
+  getSiblingPrefetchRanges,
+} from '@utils';
 
 import { useBoundStore, type SliceCreator } from './bound.store';
 
@@ -26,6 +32,31 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
   set,
   getState
 ) => {
+  const cache = createCalendarRangeCache<Note[]>();
+  let cacheVersion = 0;
+
+  const clearCache = () => {
+    cache.clear();
+    cacheVersion += 1;
+  };
+
+  const loadRange = (range: CalendarRange) => {
+    return cache.load(range, () => {
+      return listNotes([
+        toZoned(range[0], getLocalTimeZone()),
+        toZoned(range[1], getLocalTimeZone()),
+      ]);
+    });
+  };
+
+  const prefetchSiblingRanges = (range: CalendarRange) => {
+    getSiblingPrefetchRanges(range).forEach((siblingRange) => {
+      void loadRange(siblingRange).catch(() => {
+        return undefined;
+      });
+    });
+  };
+
   return {
     notes: {},
     notesByOccurrenceId: {},
@@ -34,6 +65,8 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
     noteActions: {
       addNote: async (note: NotesInsert) => {
         const newNote = await createNote(note);
+
+        clearCache();
 
         set(
           (state) => {
@@ -52,6 +85,8 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
       },
 
       clearNotes: () => {
+        clearCache();
+
         set(
           (state) => {
             state.notes = {};
@@ -65,6 +100,8 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
 
       deleteNote: async (id: Note['id']) => {
         await destroyNote(id);
+
+        clearCache();
 
         set(
           (state) => {
@@ -84,7 +121,6 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
       fetchNotes: async () => {
         const {
           calendarRange: [rangeStart, rangeEnd],
-          notesFetchedRange,
           user,
         } = getState();
 
@@ -92,19 +128,24 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
           return;
         }
 
-        const isCached =
-          notesFetchedRange &&
-          notesFetchedRange[0].compare(rangeStart) <= 0 &&
-          notesFetchedRange[1].compare(rangeEnd) >= 0;
+        const range: CalendarRange = [rangeStart, rangeEnd];
+        const cachedNotes = cache.get(range);
+        const currentRequest = cachedNotes ? null : loadRange(range);
 
-        if (isCached) {
+        prefetchSiblingRanges(range);
+
+        const requestVersion = cacheVersion;
+        const notes = cachedNotes ?? (await currentRequest!);
+        const currentState = getState();
+
+        if (
+          requestVersion !== cacheVersion ||
+          currentState.user?.id !== user.id ||
+          currentState.calendarRange[0].compare(rangeStart) !== 0 ||
+          currentState.calendarRange[1].compare(rangeEnd) !== 0
+        ) {
           return;
         }
-
-        const notes = await listNotes([
-          toZoned(rangeStart, getLocalTimeZone()),
-          toZoned(rangeEnd, getLocalTimeZone()),
-        ]);
 
         set(
           (state) => {
@@ -116,12 +157,16 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
             state.notesFetchedRange = [rangeStart, rangeEnd];
           },
           undefined,
-          'noteActions.fetchNotes'
+          cachedNotes
+            ? 'noteActions.fetchNotes.cacheHit'
+            : 'noteActions.fetchNotes.cacheMiss'
         );
       },
 
       updateNote: async (id: Note['id'], note: NotesUpdate) => {
         const updatedNote = await updateNote(id, note);
+
+        clearCache();
 
         set(
           (state) => {

--- a/src/stores/occurrences.store.ts
+++ b/src/stores/occurrences.store.ts
@@ -18,6 +18,11 @@ import {
   createOccurrence,
   destroyOccurrence,
 } from '@services';
+import {
+  type CalendarRange,
+  createCalendarRangeCache,
+  getSiblingPrefetchRanges,
+} from '@utils';
 
 import { useBoundStore, type SliceCreator } from './bound.store';
 
@@ -48,10 +53,80 @@ const toClientOccurrence = (occurrence: RawOccurrence) => {
   };
 };
 
+const getOccurrencesInRange = (
+  occurrences: Occurrence[],
+  [rangeStart, rangeEnd]: CalendarRange
+) => {
+  const zonedStart = toZoned(rangeStart, getLocalTimeZone());
+  const zonedEnd = toZoned(rangeEnd, getLocalTimeZone());
+
+  return occurrences.filter((occurrence) => {
+    return (
+      occurrence.occurredAt.compare(zonedStart) >= 0 &&
+      occurrence.occurredAt.compare(zonedEnd) <= 0
+    );
+  });
+};
+
+const buildOccurrencesByDate = (
+  occurrences: Occurrence[],
+  [rangeStart, rangeEnd]: CalendarRange
+) => {
+  const occurrencesByDate: Record<
+    string,
+    Record<Occurrence['id'], Occurrence>
+  > = {};
+
+  let currentDate = toCalendarDate(rangeStart);
+  const endDate = toCalendarDate(rangeEnd);
+
+  while (currentDate.compare(endDate) <= 0) {
+    occurrencesByDate[currentDate.toString()] = {};
+    currentDate = currentDate.add({ days: 1 });
+  }
+
+  occurrences.forEach((occurrence) => {
+    const dateKey = toCalendarDate(occurrence.occurredAt).toString();
+
+    if (occurrencesByDate[dateKey]) {
+      occurrencesByDate[dateKey][occurrence.id] = occurrence;
+    }
+  });
+
+  return occurrencesByDate;
+};
+
 export const createOccurrencesSlice: SliceCreator<keyof OccurrencesSlice> = (
   set,
   getState
 ) => {
+  const cache = createCalendarRangeCache<Occurrence[]>();
+  let cacheVersion = 0;
+
+  const clearCache = () => {
+    cache.clear();
+    cacheVersion += 1;
+  };
+
+  const loadRange = (range: CalendarRange) => {
+    return cache.load(range, async () => {
+      const occurrences = await listOccurrences([
+        toZoned(range[0], getLocalTimeZone()),
+        toZoned(range[1], getLocalTimeZone()),
+      ]);
+
+      return occurrences.map(toClientOccurrence);
+    });
+  };
+
+  const prefetchSiblingRanges = (range: CalendarRange) => {
+    getSiblingPrefetchRanges(range).forEach((siblingRange) => {
+      void loadRange(siblingRange).catch(() => {
+        return undefined;
+      });
+    });
+  };
+
   return {
     occurrences: [],
     occurrencesByDate: {},
@@ -62,6 +137,8 @@ export const createOccurrencesSlice: SliceCreator<keyof OccurrencesSlice> = (
         const nextOccurrence = await createOccurrence(occurrence);
 
         const clientOccurrence = toClientOccurrence(nextOccurrence);
+
+        clearCache();
 
         set(
           (state) => {
@@ -88,6 +165,8 @@ export const createOccurrencesSlice: SliceCreator<keyof OccurrencesSlice> = (
       },
 
       clearOccurrences: () => {
+        clearCache();
+
         set(
           (state) => {
             state.occurrences = [];
@@ -102,7 +181,6 @@ export const createOccurrencesSlice: SliceCreator<keyof OccurrencesSlice> = (
       fetchOccurrences: async () => {
         const {
           calendarRange: [rangeStart, rangeEnd],
-          occurrencesFetchedRange,
           user,
         } = getState();
 
@@ -110,45 +188,27 @@ export const createOccurrencesSlice: SliceCreator<keyof OccurrencesSlice> = (
           return;
         }
 
-        const isCached =
-          occurrencesFetchedRange &&
-          occurrencesFetchedRange[0].compare(rangeStart) <= 0 &&
-          occurrencesFetchedRange[1].compare(rangeEnd) >= 0;
+        const range: CalendarRange = [rangeStart, rangeEnd];
+        const cachedOccurrences = cache.get(range);
+        const currentRequest = cachedOccurrences ? null : loadRange(range);
 
-        if (isCached) {
-          const { occurrences: existingOccurrences } = getState();
-          const zonedStart = toZoned(rangeStart, getLocalTimeZone());
-          const zonedEnd = toZoned(rangeEnd, getLocalTimeZone());
+        prefetchSiblingRanges(range);
 
-          const occurrencesByDate: Record<
-            string,
-            Record<Occurrence['id'], Occurrence>
-          > = {};
-
-          let currentDate = toCalendarDate(rangeStart);
-          const endDate = toCalendarDate(rangeEnd);
-
-          while (currentDate.compare(endDate) <= 0) {
-            occurrencesByDate[currentDate.toString()] = {};
-            currentDate = currentDate.add({ days: 1 });
-          }
-
-          existingOccurrences.forEach((occurrence) => {
-            if (
-              occurrence.occurredAt.compare(zonedStart) >= 0 &&
-              occurrence.occurredAt.compare(zonedEnd) <= 0
-            ) {
-              const dateKey = toCalendarDate(occurrence.occurredAt).toString();
-
-              if (occurrencesByDate[dateKey]) {
-                occurrencesByDate[dateKey][occurrence.id] = occurrence;
-              }
-            }
-          });
+        if (cachedOccurrences) {
+          const visibleOccurrences = getOccurrencesInRange(
+            cachedOccurrences,
+            range
+          );
+          const occurrencesByDate = buildOccurrencesByDate(
+            visibleOccurrences,
+            range
+          );
 
           set(
             (state) => {
+              state.occurrences = visibleOccurrences;
               state.occurrencesByDate = occurrencesByDate;
+              state.occurrencesFetchedRange = range;
             },
             undefined,
             'occurrencesActions.fetchOccurrences.cacheHit'
@@ -157,37 +217,31 @@ export const createOccurrencesSlice: SliceCreator<keyof OccurrencesSlice> = (
           return;
         }
 
-        const occurrences = await listOccurrences([
-          toZoned(rangeStart, getLocalTimeZone()),
-          toZoned(rangeEnd, getLocalTimeZone()),
-        ]);
+        const requestVersion = cacheVersion;
+        const clientOccurrences = await currentRequest!;
+        const currentState = getState();
 
-        const clientOccurrences = occurrences.map(toClientOccurrence);
-
-        const occurrencesByDate: Record<
-          string,
-          Record<Occurrence['id'], Occurrence>
-        > = {};
-
-        let currentDate = toCalendarDate(rangeStart);
-        const endDate = toCalendarDate(rangeEnd);
-
-        while (currentDate.compare(endDate) <= 0) {
-          occurrencesByDate[currentDate.toString()] = {};
-          currentDate = currentDate.add({ days: 1 });
+        if (
+          requestVersion !== cacheVersion ||
+          currentState.user?.id !== user.id ||
+          currentState.calendarRange[0].compare(rangeStart) !== 0 ||
+          currentState.calendarRange[1].compare(rangeEnd) !== 0
+        ) {
+          return;
         }
 
-        clientOccurrences.forEach((occurrence) => {
-          const dateKey = toCalendarDate(occurrence.occurredAt).toString();
-
-          if (occurrencesByDate[dateKey]) {
-            occurrencesByDate[dateKey][occurrence.id] = occurrence;
-          }
-        });
+        const visibleOccurrences = getOccurrencesInRange(
+          clientOccurrences,
+          range
+        );
+        const occurrencesByDate = buildOccurrencesByDate(
+          visibleOccurrences,
+          range
+        );
 
         set(
           (state) => {
-            state.occurrences = clientOccurrences;
+            state.occurrences = visibleOccurrences;
             state.occurrencesByDate = occurrencesByDate;
             state.occurrencesFetchedRange = [rangeStart, rangeEnd];
           },
@@ -198,6 +252,8 @@ export const createOccurrencesSlice: SliceCreator<keyof OccurrencesSlice> = (
 
       removeOccurrence: async ({ id, occurredAt, photoPaths }) => {
         await destroyOccurrence({ id, photoPaths });
+
+        clearCache();
 
         set(
           (state) => {
@@ -217,6 +273,8 @@ export const createOccurrencesSlice: SliceCreator<keyof OccurrencesSlice> = (
       updateOccurrence: async ({ id, occurredAt }, body) => {
         const updatedOccurrence = await patchOccurrence(id, body);
         const updatedClientOccurrence = toClientOccurrence(updatedOccurrence);
+
+        clearCache();
 
         set(
           (state) => {

--- a/src/utils/calendar-range-cache.test.ts
+++ b/src/utils/calendar-range-cache.test.ts
@@ -1,0 +1,106 @@
+import { CalendarDateTime } from '@internationalized/date';
+import { it, vi, expect, describe } from 'vitest';
+
+import {
+  type CalendarRange,
+  createCalendarRangeCache,
+  getSiblingPrefetchRanges,
+} from './calendar-range-cache';
+
+const range = (startDay: number, endDay: number): CalendarRange => {
+  return [
+    new CalendarDateTime(2026, 1, startDay),
+    new CalendarDateTime(2026, 1, endDay, 23, 59, 59, 999),
+  ];
+};
+
+describe('createCalendarRangeCache', () => {
+  it('returns an exact cached range', async () => {
+    const cache = createCalendarRangeCache<string[]>();
+    const loader = vi.fn().mockResolvedValue(['current']);
+
+    await cache.load(range(5, 11), loader);
+
+    expect(cache.get(range(5, 11))).toEqual(['current']);
+    expect(loader).toHaveBeenCalledOnce();
+  });
+
+  it('returns a cached range that contains the requested range', async () => {
+    const cache = createCalendarRangeCache<string[]>();
+    const innerLoader = vi.fn().mockResolvedValue(['inner']);
+
+    await cache.load(range(1, 20), async () => {
+      return ['containing'];
+    });
+
+    expect(cache.get(range(5, 11))).toEqual(['containing']);
+    await expect(cache.load(range(5, 11), innerLoader)).resolves.toEqual([
+      'containing',
+    ]);
+    expect(innerLoader).not.toHaveBeenCalled();
+  });
+
+  it('prefers the most specific containing range', async () => {
+    const cache = createCalendarRangeCache<string[]>();
+
+    await cache.load(range(5, 11), async () => {
+      return ['exact'];
+    });
+    await cache.load(range(1, 20), async () => {
+      return ['large'];
+    });
+
+    expect(cache.get(range(5, 11))).toEqual(['exact']);
+  });
+
+  it('deduplicates requests for the same range', async () => {
+    const cache = createCalendarRangeCache<string[]>();
+    const loader = vi.fn().mockResolvedValue(['current']);
+
+    const first = cache.load(range(5, 11), loader);
+    const second = cache.load(range(5, 11), loader);
+
+    await Promise.all([first, second]);
+
+    expect(loader).toHaveBeenCalledOnce();
+  });
+
+  it('does not cache a request completed after the cache is cleared', async () => {
+    const cache = createCalendarRangeCache<string[]>();
+    let resolveRequest: ((value: string[]) => void) | undefined;
+    const request = cache.load(range(5, 11), () => {
+      return new Promise((resolve) => {
+        resolveRequest = resolve;
+      });
+    });
+
+    cache.clear();
+    resolveRequest?.(['stale']);
+    await request;
+
+    expect(cache.get(range(5, 11))).toBeUndefined();
+  });
+});
+
+describe('getSiblingPrefetchRanges', () => {
+  it.each([
+    { current: range(10, 10), days: 1 },
+    { current: range(5, 11), days: 7 },
+    { current: range(1, 31), days: 31 },
+  ])('covers both sibling ranges for a $days-day view', ({ current, days }) => {
+    const [previous, next] = getSiblingPrefetchRanges(current);
+    const expectedPrevious: CalendarRange = [
+      current[0].subtract({ days }),
+      current[1].subtract({ days }),
+    ];
+    const expectedNext: CalendarRange = [
+      current[0].add({ days }),
+      current[1].add({ days }),
+    ];
+
+    expect(previous[0].compare(expectedPrevious[0])).toBeLessThanOrEqual(0);
+    expect(previous[1].compare(expectedPrevious[1])).toBeGreaterThanOrEqual(0);
+    expect(next[0].compare(expectedNext[0])).toBeLessThanOrEqual(0);
+    expect(next[1].compare(expectedNext[1])).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/utils/calendar-range-cache.ts
+++ b/src/utils/calendar-range-cache.ts
@@ -1,0 +1,111 @@
+import type { CalendarDateTime } from '@internationalized/date';
+
+import { differenceInDays } from './date';
+
+export type CalendarRange = [CalendarDateTime, CalendarDateTime];
+
+type CacheEntry<T> = {
+  range: CalendarRange;
+  value: T;
+};
+
+const containsRange = (
+  [outerStart, outerEnd]: CalendarRange,
+  [innerStart, innerEnd]: CalendarRange
+) => {
+  return outerStart.compare(innerStart) <= 0 && outerEnd.compare(innerEnd) >= 0;
+};
+
+const isSameRange = (
+  [firstStart, firstEnd]: CalendarRange,
+  [secondStart, secondEnd]: CalendarRange
+) => {
+  return (
+    firstStart.compare(secondStart) === 0 && firstEnd.compare(secondEnd) === 0
+  );
+};
+
+const getRangeKey = ([rangeStart, rangeEnd]: CalendarRange) => {
+  return `${rangeStart.toString()}_${rangeEnd.toString()}`;
+};
+
+export const getSiblingPrefetchRanges = ([
+  rangeStart,
+  rangeEnd,
+]: CalendarRange): [CalendarRange, CalendarRange] => {
+  const rangeDays = Math.max(1, differenceInDays(rangeStart, rangeEnd) + 1);
+
+  return [
+    [rangeStart.subtract({ days: rangeDays }), rangeEnd],
+    [rangeStart, rangeEnd.add({ days: rangeDays })],
+  ];
+};
+
+export const createCalendarRangeCache = <T>() => {
+  let entries: CacheEntry<T>[] = [];
+  let generation = 0;
+  const pending = new Map<string, Promise<T>>();
+
+  const get = (range: CalendarRange) => {
+    const matches = entries.filter((entry) => {
+      return containsRange(entry.range, range);
+    });
+
+    return matches.reduce<CacheEntry<T> | undefined>((closest, entry) => {
+      if (!closest || containsRange(closest.range, entry.range)) {
+        return entry;
+      }
+
+      return closest;
+    }, undefined)?.value;
+  };
+
+  const load = (range: CalendarRange, loader: () => Promise<T>) => {
+    const cached = get(range);
+
+    if (cached !== undefined) {
+      return Promise.resolve(cached);
+    }
+
+    const key = getRangeKey(range);
+    const existingRequest = pending.get(key);
+
+    if (existingRequest) {
+      return existingRequest;
+    }
+
+    const requestGeneration = generation;
+    const request = loader().then((value) => {
+      if (requestGeneration === generation) {
+        entries = entries.filter((entry) => {
+          return !isSameRange(entry.range, range);
+        });
+        entries.push({ range, value });
+      }
+
+      return value;
+    });
+
+    pending.set(key, request);
+
+    const cleanUpRequest = () => {
+      if (pending.get(key) === request) {
+        pending.delete(key);
+      }
+    };
+
+    void request.then(cleanUpRequest, cleanUpRequest);
+
+    return request;
+  };
+
+  return {
+    get,
+    load,
+    clear: () => {
+      entries = [];
+      generation += 1;
+      pending.clear();
+    },
+  };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { default as buildMetricTotals } from './build-metric-totals';
 export { default as buildOccurrenceSummary } from './build-occurrence-summary';
+export * from './calendar-range-cache';
 export { default as createCalendar } from './create-calendar';
 export * from './date';
 export { default as getErrorMessage } from './get-error-message';


### PR DESCRIPTION
## Description

Brief description of your changes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved loading of notes and occurrences across calendar date ranges.
  * Added background prefetching for adjacent calendar ranges.
  * Prevented duplicate requests when the same range is loaded concurrently.

* **Bug Fixes**
  * Ensured updates, deletions, and clears refresh cached calendar data.
  * Prevented outdated requests from overwriting newer data after date-range or account changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->