### PR TITLE
feat: reuse zustand range caching on notes page

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,64 @@
+When generating a commit message, follow the Conventional Commits format. The commit message should be structured as follows:
+
+```text
+<type>[optional scope]: <description>
+
+[optional body]
+```
+
+The type should be one of the following:
+
+```json
+{
+  "types": {
+    "feat": {
+      "description": "A new feature",
+      "title": "Features"
+    },
+    "fix": {
+      "description": "A bug fix",
+      "title": "Bug Fixes"
+    },
+    "docs": {
+      "description": "Documentation only changes",
+      "title": "Documentation"
+    },
+    "style": {
+      "description": "Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)",
+      "title": "Styles"
+    },
+    "refactor": {
+      "description": "A code change that neither fixes a bug nor adds a feature",
+      "title": "Code Refactoring"
+    },
+    "perf": {
+      "description": "A code change that improves performance",
+      "title": "Performance Improvements"
+    },
+    "test": {
+      "description": "Adding missing tests or correcting existing tests",
+      "title": "Tests"
+    },
+    "build": {
+      "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
+      "title": "Builds"
+    },
+    "ci": {
+      "description": "Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)",
+      "title": "Continuous Integrations"
+    },
+    "chore": {
+      "description": "Other changes that don't modify src or test files",
+      "title": "Chores"
+    },
+    "revert": {
+      "description": "Reverts a previous commit",
+      "title": "Reverts"
+    }
+  }
+}
+```
+
+The scope should be the name of the feature affected by the change (e.g. `calendar`, `auth`, `habit`, `note`, `layout`, etc.). The scope can also be omitted if the change affects multiple features.
+
+The body should consist of a short description of the change (up to three sentences) and a list of any breaking changes.

--- a/src/components/note/NotesList.test.tsx
+++ b/src/components/note/NotesList.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { it, vi, expect, describe, beforeEach } from 'vitest';
+
+import type { NoteWithHabit } from '@models';
+import { useBoundStore } from '@stores';
+
+import NotesList from './NotesList';
+
+const listAllNotes = vi.hoisted(() => {
+  return vi.fn();
+});
+const rollbarError = vi.hoisted(() => {
+  return vi.fn();
+});
+
+vi.mock('@services', () => {
+  return { listAllNotes };
+});
+vi.mock('@rollbar/react', () => {
+  return {
+    useRollbar: () => {
+      return { error: rollbarError };
+    },
+  };
+});
+
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    disconnect = vi.fn();
+    observe = vi.fn();
+    unobserve = vi.fn();
+  }
+);
+
+const makeNote = (id: string, createdAt: string): NoteWithHabit => {
+  return {
+    content: `Content ${id}`,
+    createdAt,
+    id,
+    periodDate: '2026-07-10',
+    periodKind: 'day',
+    updatedAt: null,
+    userId: 'user-id',
+  };
+};
+
+describe('NotesList', () => {
+  beforeEach(() => {
+    listAllNotes.mockReset();
+    rollbarError.mockReset();
+    useBoundStore.getState().noteActions.clearNotes();
+  });
+
+  it('renders calendar notes from the store before the first page resolves', async () => {
+    let resolvePage: ((notes: NoteWithHabit[]) => void) | undefined;
+    listAllNotes.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePage = resolve;
+      })
+    );
+    const cachedNote = makeNote('cached', '2026-07-10T10:00:00.000Z');
+
+    useBoundStore.setState({ notes: { [cachedNote.id]: cachedNote } });
+    render(<NotesList />);
+
+    expect(screen.getByText('Content cached')).toBeInTheDocument();
+    expect(listAllNotes).toHaveBeenCalledWith({ limit: 20, page: 0 });
+
+    resolvePage?.([]);
+
+    await waitFor(() => {
+      expect(useBoundStore.getState().notesListIsLoading).toBe(false);
+    });
+  });
+
+  it('populates the Zustand store when the page is opened directly', async () => {
+    const fetchedNote = makeNote('fetched', '2026-07-10T10:00:00.000Z');
+    listAllNotes.mockResolvedValue([fetchedNote]);
+
+    render(<NotesList />);
+
+    expect(await screen.findByText('Content fetched')).toBeInTheDocument();
+    expect(useBoundStore.getState().notes[fetchedNote.id]).toEqual(fetchedNote);
+  });
+
+  it('fetches and caches subsequent pages while scrolling', async () => {
+    const firstPage = Array.from({ length: 20 }, (_, index) => {
+      return makeNote(
+        `page-0-${index}`,
+        `2026-07-10T10:${String(index).padStart(2, '0')}:00.000Z`
+      );
+    });
+    const nextPageNote = makeNote('page-1-0', '2026-07-09T10:00:00.000Z');
+    listAllNotes
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce([nextPageNote]);
+
+    const { container } = render(<NotesList />);
+
+    expect(await screen.findByText('Content page-0-0')).toBeInTheDocument();
+
+    const scrollContainer = container.querySelector('.overflow-y-auto');
+
+    expect(scrollContainer).not.toBeNull();
+    Object.defineProperties(scrollContainer!, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 100 },
+      scrollTop: { configurable: true, value: 0 },
+    });
+    fireEvent.scroll(scrollContainer!);
+
+    expect(await screen.findByText('Content page-1-0')).toBeInTheDocument();
+    expect(listAllNotes).toHaveBeenLastCalledWith({ limit: 20, page: 1 });
+    expect(useBoundStore.getState().notes[nextPageNote.id]).toEqual(
+      nextPageNote
+    );
+  });
+});

--- a/src/components/note/NotesList.tsx
+++ b/src/components/note/NotesList.tsx
@@ -1,53 +1,24 @@
 import { ScrollShadow } from '@heroui/react';
+import { useRollbar } from '@rollbar/react';
 import React from 'react';
 
 import { NoteListItem, InfinityLoader } from '@components';
-import type { NoteWithHabit } from '@models';
-import { listAllNotes } from '@services';
-
-const PAGE_SIZE = 20;
+import { useNotesList, useNoteActions, useNotesListState } from '@stores';
+import { getErrorMessage } from '@utils';
 
 const NotesList = () => {
-  const [notes, setNotes] = React.useState<NoteWithHabit[]>([]);
-  const [page, setPage] = React.useState(0);
-  const [hasMore, setHasMore] = React.useState(true);
-  const [isLoading, setIsLoading] = React.useState(false);
+  const notes = useNotesList();
+  const { fetchNextNotesPage, initializeNotesList } = useNoteActions();
+  const { hasMore, isLoading } = useNotesListState();
   const containerRef = React.useRef<HTMLDivElement>(null);
-
-  const fetchNotes = React.useCallback(
-    async (pageToFetch: number) => {
-      if (isLoading) {
-        return;
-      }
-
-      setIsLoading(true);
-
-      try {
-        const fetchedNotes = await listAllNotes({
-          limit: PAGE_SIZE,
-          page: pageToFetch,
-        });
-
-        if (fetchedNotes.length < PAGE_SIZE) {
-          setHasMore(false);
-        }
-
-        setNotes((prev) => {
-          return pageToFetch === 0 ? fetchedNotes : [...prev, ...fetchedNotes];
-        });
-      } catch (error) {
-        console.error('Failed to fetch notes:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [isLoading]
-  );
+  const rollbar = useRollbar();
 
   React.useEffect(() => {
-    void fetchNotes(0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    void initializeNotesList().catch((error: unknown) => {
+      rollbar.error('Failed to initialize notes list', getErrorMessage(error));
+      console.error('Failed to fetch notes:', error);
+    });
+  }, [initializeNotesList, rollbar]);
 
   const handleScroll = React.useCallback(
     (event: React.UIEvent<HTMLDivElement>) => {
@@ -56,12 +27,13 @@ const NotesList = () => {
         target.scrollHeight - target.scrollTop <= target.clientHeight + 50;
 
       if (scrolledToBottom && hasMore && !isLoading) {
-        const nextPage = page + 1;
-        setPage(nextPage);
-        void fetchNotes(nextPage);
+        void fetchNextNotesPage().catch((error: unknown) => {
+          rollbar.error('Failed to fetch notes', getErrorMessage(error));
+          console.error('Failed to fetch notes:', error);
+        });
       }
     },
-    [hasMore, isLoading, page, fetchNotes]
+    [fetchNextNotesPage, hasMore, isLoading, rollbar]
   );
 
   const renderEndMessage = () => {

--- a/src/stores/notes.store.ts
+++ b/src/stores/notes.store.ts
@@ -3,8 +3,20 @@ import { toZoned, getLocalTimeZone } from '@internationalized/date';
 import keyBy from 'lodash.keyby';
 import { useShallow } from 'zustand/react/shallow';
 
-import type { Note, Occurrence, NotesInsert, NotesUpdate } from '@models';
-import { listNotes, createNote, updateNote, destroyNote } from '@services';
+import type {
+  Note,
+  Occurrence,
+  NotesInsert,
+  NotesUpdate,
+  NoteWithHabit,
+} from '@models';
+import {
+  listNotes,
+  createNote,
+  updateNote,
+  destroyNote,
+  listAllNotes,
+} from '@services';
 import {
   isNoteOfPeriod,
   type CalendarRange,
@@ -19,13 +31,36 @@ export type NotesSlice = {
   notes: Record<Note['id'], Note>;
   notesByOccurrenceId: Record<Occurrence['id'], Note>;
   notesFetchedRange: [CalendarDateTime, CalendarDateTime] | null;
+  notesList: NoteWithHabit[];
+  notesListHasMore: boolean;
+  notesListIsInitialized: boolean;
+  notesListIsLoading: boolean;
+  notesListNextPage: number;
   noteActions: {
     addNote: (note: NotesInsert) => Promise<Note>;
     clearNotes: () => void;
     deleteNote: (id: Note['id']) => Promise<void>;
+    fetchNextNotesPage: () => Promise<void>;
     fetchNotes: () => Promise<void>;
+    initializeNotesList: () => Promise<void>;
     updateNote: (id: Note['id'], note: NotesUpdate) => Promise<Note>;
   };
+};
+
+const NOTES_PAGE_SIZE = 20;
+
+const mergeNotes = (...noteGroups: NoteWithHabit[][]) => {
+  const notesById = new Map<Note['id'], NoteWithHabit>();
+
+  noteGroups.flat().forEach((note) => {
+    notesById.set(note.id, note);
+  });
+
+  return [...notesById.values()].sort((first, second) => {
+    return (
+      new Date(second.createdAt).getTime() - new Date(first.createdAt).getTime()
+    );
+  });
 };
 
 export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
@@ -33,11 +68,20 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
   getState
 ) => {
   const cache = createCalendarRangeCache<Note[]>();
+  const notesListPageCache = new Map<number, NoteWithHabit[]>();
   let cacheVersion = 0;
+  let notesListCacheVersion = 0;
+  let notesListRequest: Promise<void> | null = null;
 
   const clearCache = () => {
     cache.clear();
     cacheVersion += 1;
+  };
+
+  const clearNotesListCache = () => {
+    notesListPageCache.clear();
+    notesListCacheVersion += 1;
+    notesListRequest = null;
   };
 
   const loadRange = (range: CalendarRange) => {
@@ -57,21 +101,104 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
     });
   };
 
+  const fetchNotesListPage = (page: number) => {
+    const cachedPage = notesListPageCache.get(page);
+
+    if (cachedPage) {
+      set(
+        (state) => {
+          state.notesList = mergeNotes(state.notesList, cachedPage);
+          state.notesListHasMore = cachedPage.length === NOTES_PAGE_SIZE;
+          state.notesListNextPage = Math.max(state.notesListNextPage, page + 1);
+        },
+        undefined,
+        'noteActions.fetchNotesListPage.cacheHit'
+      );
+
+      return Promise.resolve();
+    }
+
+    if (notesListRequest) {
+      return notesListRequest;
+    }
+
+    const requestVersion = notesListCacheVersion;
+
+    set(
+      (state) => {
+        state.notesListIsLoading = true;
+      },
+      undefined,
+      'noteActions.fetchNotesListPage.start'
+    );
+
+    notesListRequest = listAllNotes({ limit: NOTES_PAGE_SIZE, page })
+      .then((fetchedNotes) => {
+        if (requestVersion !== notesListCacheVersion) {
+          return;
+        }
+
+        notesListPageCache.set(page, fetchedNotes);
+
+        set(
+          (state) => {
+            fetchedNotes.forEach((note) => {
+              state.notes[note.id] = note;
+
+              if ('occurrenceId' in note && note.occurrenceId) {
+                state.notesByOccurrenceId[note.occurrenceId] = note;
+              }
+            });
+            state.notesList = mergeNotes(state.notesList, fetchedNotes);
+            state.notesListHasMore = fetchedNotes.length === NOTES_PAGE_SIZE;
+            state.notesListNextPage = page + 1;
+          },
+          undefined,
+          'noteActions.fetchNotesListPage.success'
+        );
+      })
+      .finally(() => {
+        if (requestVersion === notesListCacheVersion) {
+          set(
+            (state) => {
+              state.notesListIsLoading = false;
+            },
+            undefined,
+            'noteActions.fetchNotesListPage.finish'
+          );
+          notesListRequest = null;
+        }
+      });
+
+    return notesListRequest;
+  };
+
   return {
     notes: {},
     notesByOccurrenceId: {},
     notesFetchedRange: null,
+    notesList: [],
+    notesListHasMore: true,
+    notesListIsInitialized: false,
+    notesListIsLoading: false,
+    notesListNextPage: 0,
 
     noteActions: {
       addNote: async (note: NotesInsert) => {
         const newNote = await createNote(note);
 
         clearCache();
+        clearNotesListCache();
 
         set(
           (state) => {
             state.notesFetchedRange = null;
             state.notes[newNote.id] = newNote;
+            state.notesList = mergeNotes(state.notesList, [newNote]);
+            state.notesListHasMore = true;
+            state.notesListIsInitialized = false;
+            state.notesListIsLoading = false;
+            state.notesListNextPage = 0;
 
             if ('occurrenceId' in newNote && newNote.occurrenceId) {
               state.notesByOccurrenceId[newNote.occurrenceId] = newNote;
@@ -86,12 +213,18 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
 
       clearNotes: () => {
         clearCache();
+        clearNotesListCache();
 
         set(
           (state) => {
             state.notes = {};
             state.notesByOccurrenceId = {};
             state.notesFetchedRange = null;
+            state.notesList = [];
+            state.notesListHasMore = true;
+            state.notesListIsInitialized = false;
+            state.notesListIsLoading = false;
+            state.notesListNextPage = 0;
           },
           undefined,
           'noteActions.clearNotes'
@@ -102,12 +235,20 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
         await destroyNote(id);
 
         clearCache();
+        clearNotesListCache();
 
         set(
           (state) => {
             state.notesFetchedRange = null;
             const noteToDelete = state.notes[id];
             delete state.notes[id];
+            state.notesList = state.notesList.filter((note) => {
+              return note.id !== id;
+            });
+            state.notesListHasMore = true;
+            state.notesListIsInitialized = false;
+            state.notesListIsLoading = false;
+            state.notesListNextPage = 0;
 
             if ('occurrenceId' in noteToDelete && noteToDelete?.occurrenceId) {
               delete state.notesByOccurrenceId[noteToDelete.occurrenceId];
@@ -116,6 +257,17 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
           undefined,
           'noteActions.deleteNote'
         );
+      },
+
+      fetchNextNotesPage: async () => {
+        const { notesListHasMore, notesListIsLoading, notesListNextPage } =
+          getState();
+
+        if (!notesListHasMore || notesListIsLoading) {
+          return;
+        }
+
+        await fetchNotesListPage(notesListNextPage);
       },
 
       fetchNotes: async () => {
@@ -155,6 +307,7 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
               'occurrenceId'
             );
             state.notesFetchedRange = [rangeStart, rangeEnd];
+            state.notesList = mergeNotes(state.notesList, notes);
           },
           undefined,
           cachedNotes
@@ -163,15 +316,63 @@ export const createNotesSlice: SliceCreator<keyof NotesSlice> = (
         );
       },
 
+      initializeNotesList: async () => {
+        const { notes, notesListIsInitialized } = getState();
+
+        if (notesListIsInitialized) {
+          return;
+        }
+
+        const cachedRangeNotes = cache.values().flat();
+
+        set(
+          (state) => {
+            state.notesList = mergeNotes(
+              cachedRangeNotes,
+              Object.values(notes),
+              state.notesList
+            );
+            state.notesListIsInitialized = true;
+          },
+          undefined,
+          'noteActions.initializeNotesList'
+        );
+
+        try {
+          await fetchNotesListPage(0);
+        } catch (error) {
+          set(
+            (state) => {
+              state.notesListIsInitialized = false;
+            },
+            undefined,
+            'noteActions.initializeNotesList.error'
+          );
+
+          throw error;
+        }
+      },
+
       updateNote: async (id: Note['id'], note: NotesUpdate) => {
         const updatedNote = await updateNote(id, note);
 
         clearCache();
+        clearNotesListCache();
 
         set(
           (state) => {
             state.notesFetchedRange = null;
             state.notes[id] = updatedNote;
+            state.notesList = mergeNotes(
+              state.notesList.filter((note) => {
+                return note.id !== id;
+              }),
+              [updatedNote]
+            );
+            state.notesListHasMore = true;
+            state.notesListIsInitialized = false;
+            state.notesListIsLoading = false;
+            state.notesListNextPage = 0;
 
             if ('occurrenceId' in updatedNote && updatedNote.occurrenceId) {
               state.notesByOccurrenceId[updatedNote.occurrenceId] = updatedNote;
@@ -199,6 +400,23 @@ export const useNotesByOccurrenceId = () => {
   return useBoundStore((state) => {
     return state.notesByOccurrenceId;
   });
+};
+
+export const useNotesList = () => {
+  return useBoundStore((state) => {
+    return state.notesList;
+  });
+};
+
+export const useNotesListState = () => {
+  return useBoundStore(
+    useShallow((state) => {
+      return {
+        hasMore: state.notesListHasMore,
+        isLoading: state.notesListIsLoading,
+      };
+    })
+  );
 };
 
 export const usePeriodNotes = () => {

--- a/src/utils/calendar-range-cache.test.ts
+++ b/src/utils/calendar-range-cache.test.ts
@@ -65,6 +65,19 @@ describe('createCalendarRangeCache', () => {
     expect(loader).toHaveBeenCalledOnce();
   });
 
+  it('exposes cached values for consumers that span multiple ranges', async () => {
+    const cache = createCalendarRangeCache<string[]>();
+
+    await cache.load(range(1, 5), async () => {
+      return ['first'];
+    });
+    await cache.load(range(10, 15), async () => {
+      return ['second'];
+    });
+
+    expect(cache.values()).toEqual([['first'], ['second']]);
+  });
+
   it('does not cache a request completed after the cache is cleared', async () => {
     const cache = createCalendarRangeCache<string[]>();
     let resolveRequest: ((value: string[]) => void) | undefined;

--- a/src/utils/calendar-range-cache.ts
+++ b/src/utils/calendar-range-cache.ts
@@ -107,5 +107,10 @@ export const createCalendarRangeCache = <T>() => {
       generation += 1;
       pending.clear();
     },
+    values: () => {
+      return entries.map((entry) => {
+        return entry.value;
+      });
+    },
   };
 };


### PR DESCRIPTION
## Description

Brief description of your changes.

[skip relative-ci]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notes now load progressively as you scroll, with cached results displayed immediately.
  * Added support for maintaining and updating a unified notes list as notes are created, edited, or deleted.
  * Calendar-range caches can now expose all currently cached values.

* **Bug Fixes**
  * Improved notes loading state and error handling during initial and subsequent page loads.

* **Tests**
  * Added coverage for cached notes, pagination, infinite scrolling, and multi-range cache values.

* **Documentation**
  * Added commit message formatting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->