### PR TITLE
feat(layout): add responsive sidebar navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {
   AppHeader,
+  AppSidebar,
   NoteDrawer,
   InfinityLoader,
   OccurrenceDrawer,
@@ -47,9 +48,12 @@ const App = () => {
       <NoteDrawer />
       <OccurrenceDrawer />
       <ConfirmationDialog />
-      <main className="flex h-full flex-1 flex-col items-start bg-white max-md:pb-11.25 dark:bg-black">
-        <AppRoutes />
-      </main>
+      <div className="flex w-full flex-1 items-stretch">
+        <AppSidebar />
+        <main className="flex h-full min-w-0 flex-1 flex-col items-start bg-white max-md:pb-11.25 dark:bg-black">
+          <AppRoutes />
+        </main>
+      </div>
     </>
   );
 };

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Route, Routes, Navigate } from 'react-router';
+import { Route, Routes, Navigate, useLocation } from 'react-router';
 
 import {
   LoginPage,
   NotesPage,
   HabitsPage,
-  AccountPage,
   RegisterPage,
+  SettingsPage,
   DayCalendarPage,
   OAuthConsentPage,
   HabitDetailsPage,
@@ -15,6 +15,12 @@ import {
   ResetPasswordPage,
   AnonymousLoginPage,
 } from '@pages';
+
+const AccountRedirect = () => {
+  const { hash, search } = useLocation();
+
+  return <Navigate replace to={`/settings${search}${hash}`} />;
+};
 
 const AppRoutes = () => {
   return (
@@ -34,7 +40,8 @@ const AppRoutes = () => {
       <Route path="/habits" element={<HabitsPage />} />
       <Route path="/habits/:habitId" element={<HabitDetailsPage />} />
       <Route path="/notes" element={<NotesPage />} />
-      <Route path="/account" element={<AccountPage />} />
+      <Route path="/settings" element={<SettingsPage />} />
+      <Route path="/account" element={<AccountRedirect />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/anonymous-login" element={<AnonymousLoginPage />} />
       <Route path="/register" element={<RegisterPage />} />

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,40 +1,25 @@
-import { Label, Dropdown, Separator } from '@heroui/react';
 import { today, getLocalTimeZone } from '@internationalized/date';
 import {
   ListIcon,
-  NoteIcon,
-  UserIcon,
-  RepeatIcon,
-  MapPinIcon,
-  SignOutIcon,
-  GithubLogoIcon,
   NotePencilIcon,
-  RoadHorizonIcon,
-  CalendarDotsIcon,
   CalendarCheckIcon,
-  ArrowSquareOutIcon,
 } from '@phosphor-icons/react';
-import { useLocation, useNavigate } from 'react-router';
 
-import { CustomKbd, CustomButton } from '@components';
+import { UserMenu, CustomKbd, CustomButton } from '@components';
 import { useScreenWidth } from '@hooks';
-import { signOut } from '@services';
 import {
   useUser,
   useNoteDrawerActions,
+  useMobileSidebarActions,
   useOccurrenceDrawerActions,
 } from '@stores';
 
 import ThemeToggle from './ThemeToggle';
 
-const ROADMAP_URL = 'https://habitrack.featurebase.app/roadmap';
-const GITHUB_URL = 'https://github.com/domhhv/habitrack';
-
 const Header = () => {
   const user = useUser();
-  const navigate = useNavigate();
   const { isMobile } = useScreenWidth();
-  const { pathname } = useLocation();
+  const { openMobileSidebar } = useMobileSidebarActions();
   const { openNoteDrawer } = useNoteDrawerActions();
   const { openOccurrenceDrawer } = useOccurrenceDrawerActions();
 
@@ -48,178 +33,23 @@ const Header = () => {
     });
   };
 
-  const navItems = [
-    {
-      href: '/calendar/month',
-      icon: CalendarDotsIcon,
-      id: 'calendar',
-      isActive: pathname.startsWith('/calendar'),
-      label: 'Calendar',
-    },
-    ...(user
-      ? ([
-          {
-            href: '/habits',
-            icon: RepeatIcon,
-            id: 'habits',
-            isActive: pathname.startsWith('/habits'),
-            label: 'Habits',
-          },
-          {
-            href: '/notes',
-            icon: NoteIcon,
-            id: 'notes',
-            isActive: pathname === '/notes',
-            label: 'Notes',
-          },
-          {
-            href: '/account',
-            icon: UserIcon,
-            id: 'account',
-            isActive: pathname === '/account',
-            label: 'Account',
-          },
-        ] as const)
-      : []),
-  ] as const;
-
-  const activeLabel =
-    navItems.find((item) => {
-      return item.isActive;
-    })?.label ?? 'Menu';
-
   return (
-    <nav className="bg-background border-border sticky top-0 z-50 h-16 w-full border-b">
-      <header className="flex h-full w-full items-center justify-between px-8 lg:px-8">
-        <div className="flex items-center gap-2">
-          <Dropdown>
-            <CustomButton
-              size="sm"
-              variant="outline"
-              aria-label="Open navigation menu"
-            >
-              <ListIcon size={isMobile ? 16 : 18} />
-              <span>{activeLabel}</span>
-            </CustomButton>
-            <Dropdown.Popover className="min-w-[250px]">
-              <Dropdown.Menu aria-label="Navigation">
-                <Dropdown.Section>
-                  {navItems.map(({ href, icon: Icon, id, isActive, label }) => {
-                    return (
-                      <Dropdown.Item
-                        id={id}
-                        key={id}
-                        href={href}
-                        textValue={label}
-                        className="justify-between"
-                      >
-                        <div className="flex items-center gap-2">
-                          <Icon className="size-4 shrink-0" />
-                          <Label>{label}</Label>
-                        </div>
-                        {isActive && user && (
-                          <div className="text-muted flex items-center gap-1 text-xs">
-                            <MapPinIcon />
-                            <span className="ms-auto">You&apos;re here</span>
-                          </div>
-                        )}
-                      </Dropdown.Item>
-                    );
-                  })}
-                </Dropdown.Section>
-                <Separator className="bg-muted/25" />
-                <Dropdown.Section>
-                  <Dropdown.Item
-                    id="roadmap"
-                    target="_blank"
-                    href={ROADMAP_URL}
-                    textValue="Roadmap"
-                    rel="noopener noreferrer"
-                    className="justify-between"
-                  >
-                    <div className="flex items-center gap-2">
-                      <RoadHorizonIcon className="size-4 shrink-0" />
-                      <Label>Roadmap</Label>
-                    </div>
-                    <ArrowSquareOutIcon className="text-muted/50 size-4 shrink-0" />
-                  </Dropdown.Item>
-                  <Dropdown.Item
-                    target="_blank"
-                    id="source-code"
-                    href={GITHUB_URL}
-                    rel="noopener noreferrer"
-                    className="justify-between"
-                    textValue="Source Code on GitHub"
-                  >
-                    <div className="flex items-center gap-2">
-                      <GithubLogoIcon className="size-4 shrink-0" />
-                      <Label>Source Code on GitHub</Label>
-                    </div>
-                    <ArrowSquareOutIcon className="text-muted/50 size-4 shrink-0 justify-self-end" />
-                  </Dropdown.Item>
-                </Dropdown.Section>
-                {!!user && (
-                  <>
-                    <Separator className="bg-muted/25" />
-                    <Dropdown.Section>
-                      <Dropdown.Item
-                        id="logout"
-                        variant="danger"
-                        onAction={signOut}
-                        textValue="Log Out"
-                      >
-                        <SignOutIcon className="text-danger size-4 shrink-0" />
-                        <Label>Log Out</Label>
-                      </Dropdown.Item>
-                    </Dropdown.Section>
-                  </>
-                )}
-              </Dropdown.Menu>
-            </Dropdown.Popover>
-          </Dropdown>
-        </div>
+    <nav className="bg-background border-border sticky top-0 z-50 h-16 w-full border-b lg:hidden">
+      <header className="flex h-full w-full items-center justify-between px-4 md:px-8">
+        <CustomButton
+          size="sm"
+          isIconOnly
+          variant="outline"
+          onPress={openMobileSidebar}
+          aria-label="Open navigation menu"
+        >
+          <ListIcon size={isMobile ? 16 : 18} />
+        </CustomButton>
         <div className="flex items-center gap-2">
           <ThemeToggle />
-          {!!user && (
-            <div className="bg-background-secondary border-border dark:border-border fixed right-0 bottom-0 left-0 z-50 flex w-full gap-2 border-t p-2 px-4 md:right-4 md:bottom-4 md:left-auto md:w-auto md:border-0 md:bg-transparent md:p-0 xl:static xl:right-auto xl:bottom-auto xl:border-0 xl:bg-transparent xl:p-0 dark:md:bg-transparent dark:xl:bg-transparent">
-              <CustomButton
-                size="sm"
-                variant="bordered"
-                fullWidth={isMobile}
-                onPress={dispatchNoteDrawerOpen}
-                className="flex-1 max-md:h-8 max-md:gap-1 max-md:rounded-full md:flex-none"
-              >
-                <NotePencilIcon size={isMobile ? 12 : 16} />
-                Note
-                <CustomKbd
-                  isSolid
-                  size="sm"
-                  variant="light"
-                  shortcutParams={['n', dispatchNoteDrawerOpen]}
-                >
-                  N
-                </CustomKbd>
-              </CustomButton>
-              <CustomButton
-                size="sm"
-                variant="primary"
-                fullWidth={isMobile}
-                onPress={dispatchOccurrenceDrawerOpen}
-                className="flex-1 max-md:h-8 max-md:gap-1 max-md:rounded-full md:flex-none"
-              >
-                <CalendarCheckIcon size={isMobile ? 12 : 16} />
-                Log
-                <CustomKbd
-                  size="sm"
-                  variant="default"
-                  shortcutParams={['l', dispatchOccurrenceDrawerOpen]}
-                >
-                  L
-                </CustomKbd>
-              </CustomButton>
-            </div>
-          )}
-          {!user && (
+          {user ? (
+            <UserMenu />
+          ) : (
             <>
               <CustomButton
                 size="sm"
@@ -228,16 +58,7 @@ const Header = () => {
                 data-testid="login-button"
               >
                 Log In
-                <CustomKbd
-                  size="sm"
-                  variant="default"
-                  shortcutParams={[
-                    'i',
-                    () => {
-                      navigate('/login');
-                    },
-                  ]}
-                >
+                <CustomKbd size="sm" variant="default">
                   I
                 </CustomKbd>
               </CustomButton>
@@ -248,16 +69,7 @@ const Header = () => {
                 data-testid="register-button"
               >
                 Join
-                <CustomKbd
-                  size="sm"
-                  variant="default"
-                  shortcutParams={[
-                    'j',
-                    () => {
-                      navigate('/register');
-                    },
-                  ]}
-                >
+                <CustomKbd size="sm" variant="default">
                   J
                 </CustomKbd>
               </CustomButton>
@@ -265,6 +77,36 @@ const Header = () => {
           )}
         </div>
       </header>
+      {!!user && (
+        <div className="bg-background-secondary border-border dark:border-border fixed right-0 bottom-0 left-0 z-50 flex w-full gap-2 border-t p-2 px-4 md:right-4 md:bottom-4 md:left-auto md:w-auto md:border-0 md:bg-transparent md:p-0 dark:md:bg-transparent">
+          <CustomButton
+            size="sm"
+            variant="bordered"
+            fullWidth={isMobile}
+            onPress={dispatchNoteDrawerOpen}
+            className="flex-1 max-md:h-8 max-md:gap-1 max-md:rounded-full md:flex-none"
+          >
+            <NotePencilIcon size={isMobile ? 12 : 16} />
+            Note
+            <CustomKbd isSolid size="sm" variant="light">
+              N
+            </CustomKbd>
+          </CustomButton>
+          <CustomButton
+            size="sm"
+            variant="primary"
+            fullWidth={isMobile}
+            onPress={dispatchOccurrenceDrawerOpen}
+            className="flex-1 max-md:h-8 max-md:gap-1 max-md:rounded-full md:flex-none"
+          >
+            <CalendarCheckIcon size={isMobile ? 12 : 16} />
+            Log
+            <CustomKbd size="sm" variant="default">
+              L
+            </CustomKbd>
+          </CustomButton>
+        </div>
+      )}
     </nav>
   );
 };

--- a/src/components/header/index.ts
+++ b/src/components/header/index.ts
@@ -1,1 +1,2 @@
 export { default as AppHeader } from './Header';
+export { default as ThemeToggle } from './ThemeToggle';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,5 +6,6 @@ export * from './header';
 export * from './metric';
 export * from './note';
 export * from './occurrence';
+export * from './sidebar';
 export * from './stock';
 export * from './trait';

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,0 +1,111 @@
+import { cn, Drawer } from '@heroui/react';
+import { today, getLocalTimeZone } from '@internationalized/date';
+import React from 'react';
+import { useNavigate } from 'react-router';
+
+import { useSidebarMode, useKeyboardShortcut } from '@hooks';
+import {
+  useUser,
+  useNoteDrawerActions,
+  useMobileSidebarState,
+  useMobileSidebarActions,
+  useOccurrenceDrawerActions,
+} from '@stores';
+
+import SidebarContent from './SidebarContent';
+
+const Sidebar = () => {
+  const user = useUser();
+  const navigate = useNavigate();
+  const { sidebarMode } = useSidebarMode();
+  const [isHovered, setIsHovered] = React.useState(false);
+  const isMobileSidebarOpen = useMobileSidebarState();
+  const { closeMobileSidebar } = useMobileSidebarActions();
+  const { openNoteDrawer } = useNoteDrawerActions();
+  const { openOccurrenceDrawer } = useOccurrenceDrawerActions();
+
+  const dispatchNoteDrawerOpen = () => {
+    openNoteDrawer(today(getLocalTimeZone()), 'day');
+  };
+
+  const dispatchOccurrenceDrawerOpen = () => {
+    openOccurrenceDrawer({
+      dayToLog: today(getLocalTimeZone()),
+    });
+  };
+
+  useKeyboardShortcut('l', dispatchOccurrenceDrawerOpen, { enabled: !!user });
+  useKeyboardShortcut('n', dispatchNoteDrawerOpen, { enabled: !!user });
+  useKeyboardShortcut(
+    'i',
+    () => {
+      navigate('/login');
+    },
+    { enabled: !user }
+  );
+  useKeyboardShortcut(
+    'j',
+    () => {
+      navigate('/register');
+    },
+    { enabled: !user }
+  );
+
+  const isExpanded =
+    sidebarMode === 'expanded' || (sidebarMode === 'hover' && isHovered);
+
+  return (
+    <>
+      <div
+        className={cn(
+          'shrink-0 transition-[width] duration-300 max-lg:hidden',
+          sidebarMode === 'expanded' ? 'w-64' : 'w-16'
+        )}
+      >
+        <aside
+          onMouseLeave={() => {
+            setIsHovered(false);
+          }}
+          onMouseEnter={() => {
+            if (sidebarMode === 'hover') {
+              setIsHovered(true);
+            }
+          }}
+          className={cn(
+            'bg-background border-border sticky top-0 z-40 flex h-dvh flex-col border-r transition-[width] duration-300',
+            isExpanded ? 'w-64' : 'w-16',
+            sidebarMode === 'hover' && isExpanded && 'shadow-xl'
+          )}
+        >
+          <SidebarContent
+            isExpanded={isExpanded}
+            hasTooltips={sidebarMode === 'collapsed'}
+          />
+        </aside>
+      </div>
+      <Drawer
+        isOpen={isMobileSidebarOpen}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            closeMobileSidebar();
+          }
+        }}
+      >
+        <Drawer.Backdrop className="lg:hidden">
+          <Drawer.Content placement="left" className="w-72 max-w-[85vw] p-0">
+            <Drawer.Dialog className="h-full p-0">
+              <Drawer.CloseTrigger />
+              <SidebarContent
+                isOverlay
+                isExpanded
+                onClose={closeMobileSidebar}
+              />
+            </Drawer.Dialog>
+          </Drawer.Content>
+        </Drawer.Backdrop>
+      </Drawer>
+    </>
+  );
+};
+
+export default Sidebar;

--- a/src/components/sidebar/SidebarContent.tsx
+++ b/src/components/sidebar/SidebarContent.tsx
@@ -1,0 +1,319 @@
+import { cn, Link, Tooltip } from '@heroui/react';
+import { today, getLocalTimeZone } from '@internationalized/date';
+import {
+  NoteIcon,
+  GearIcon,
+  RepeatIcon,
+  SignInIcon,
+  UserPlusIcon,
+  GithubLogoIcon,
+  NotePencilIcon,
+  RoadHorizonIcon,
+  CalendarDotsIcon,
+  CalendarCheckIcon,
+  ArrowSquareOutIcon,
+} from '@phosphor-icons/react';
+import type { ReactNode } from 'react';
+import { useLocation } from 'react-router';
+
+import { CustomKbd, ThemeToggle, CustomButton } from '@components';
+import {
+  useUser,
+  useNoteDrawerActions,
+  useOccurrenceDrawerActions,
+} from '@stores';
+
+import SidebarModeSelect from './SidebarModeSelect';
+import ThemeMenu from './ThemeMenu';
+import UserMenu from './UserMenu';
+
+const ROADMAP_URL = 'https://habitrack.featurebase.app/roadmap';
+const GITHUB_URL = 'https://github.com/domhhv/habitrack';
+
+const EXTERNAL_LINKS = [
+  {
+    href: ROADMAP_URL,
+    icon: RoadHorizonIcon,
+    id: 'roadmap',
+    label: 'Roadmap',
+  },
+  {
+    href: GITHUB_URL,
+    icon: GithubLogoIcon,
+    id: 'source-code',
+    label: 'Source Code on GitHub',
+  },
+] as const;
+
+type SidebarTooltipProps = {
+  children: ReactNode;
+  content: ReactNode;
+  isEnabled: boolean;
+};
+
+const SidebarTooltip = ({
+  children,
+  content,
+  isEnabled,
+}: SidebarTooltipProps) => {
+  if (!isEnabled) {
+    return children;
+  }
+
+  return (
+    <Tooltip closeDelay={0}>
+      <Tooltip.Trigger>{children}</Tooltip.Trigger>
+      <Tooltip.Content placement="right">{content}</Tooltip.Content>
+    </Tooltip>
+  );
+};
+
+type SidebarContentProps = {
+  hasTooltips?: boolean;
+  isExpanded: boolean;
+  isOverlay?: boolean;
+  onClose?: () => void;
+};
+
+const SidebarContent = ({
+  hasTooltips = false,
+  isExpanded,
+  isOverlay = false,
+  onClose,
+}: SidebarContentProps) => {
+  const user = useUser();
+  const { pathname } = useLocation();
+  const { openNoteDrawer } = useNoteDrawerActions();
+  const { openOccurrenceDrawer } = useOccurrenceDrawerActions();
+
+  const dispatchNoteDrawerOpen = () => {
+    onClose?.();
+    openNoteDrawer(today(getLocalTimeZone()), 'day');
+  };
+
+  const dispatchOccurrenceDrawerOpen = () => {
+    onClose?.();
+    openOccurrenceDrawer({
+      dayToLog: today(getLocalTimeZone()),
+    });
+  };
+
+  const navItems = [
+    {
+      href: '/calendar/month',
+      icon: CalendarDotsIcon,
+      id: 'calendar',
+      isActive: pathname.startsWith('/calendar'),
+      label: 'Calendar',
+    },
+    ...(user
+      ? ([
+          {
+            href: '/habits',
+            icon: RepeatIcon,
+            id: 'habits',
+            isActive: pathname.startsWith('/habits'),
+            label: 'Habits',
+          },
+          {
+            href: '/notes',
+            icon: NoteIcon,
+            id: 'notes',
+            isActive: pathname === '/notes',
+            label: 'Notes',
+          },
+          {
+            href: '/settings',
+            icon: GearIcon,
+            id: 'settings',
+            isActive: pathname === '/settings',
+            label: 'Settings',
+          },
+        ] as const)
+      : []),
+  ] as const;
+
+  const getNavLinkClassName = (isActive: boolean) => {
+    return cn(
+      'text-foreground hover:bg-background-secondary flex h-9 w-full items-center gap-2.5 rounded-lg px-2.5 text-sm font-medium',
+      !isExpanded && 'justify-center px-0',
+      isActive && 'bg-accent-soft text-accent hover:bg-accent-soft-hover'
+    );
+  };
+
+  const getActionClassName = () => {
+    return cn(
+      'text-foreground hover:bg-background-secondary h-9 w-full justify-start gap-2.5 rounded-lg px-2.5 text-sm font-medium has-[kbd]:gap-2.5 has-[kbd]:pr-2.5',
+      !isExpanded && 'justify-center px-0'
+    );
+  };
+
+  return (
+    <div
+      className={cn(
+        'flex h-full w-full flex-col gap-4 overflow-x-hidden overflow-y-auto p-3',
+        !isExpanded && 'items-center px-2',
+        isOverlay && 'pt-12'
+      )}
+    >
+      {!!user && !isOverlay && (
+        <div className="border-border flex w-full flex-col gap-1 border-b pb-3">
+          <SidebarTooltip content="Log (L)" isEnabled={hasTooltips}>
+            <CustomButton
+              variant="ghost"
+              aria-label="Log an occurrence"
+              className={getActionClassName()}
+              onPress={dispatchOccurrenceDrawerOpen}
+            >
+              <span className="bg-accent text-accent-foreground flex size-6 shrink-0 items-center justify-center rounded-full">
+                <CalendarCheckIcon size={14} />
+              </span>
+              {isExpanded && (
+                <>
+                  <span className="truncate">Log</span>
+                  <CustomKbd size="sm" variant="default" className="ms-auto">
+                    L
+                  </CustomKbd>
+                </>
+              )}
+            </CustomButton>
+          </SidebarTooltip>
+          <SidebarTooltip content="Note (N)" isEnabled={hasTooltips}>
+            <CustomButton
+              variant="ghost"
+              aria-label="Write a note"
+              className={getActionClassName()}
+              onPress={dispatchNoteDrawerOpen}
+            >
+              <span className="bg-accent-soft text-accent flex size-6 shrink-0 items-center justify-center rounded-full">
+                <NotePencilIcon size={14} />
+              </span>
+              {isExpanded && (
+                <>
+                  <span className="truncate">Note</span>
+                  <CustomKbd size="sm" variant="default" className="ms-auto">
+                    N
+                  </CustomKbd>
+                </>
+              )}
+            </CustomButton>
+          </SidebarTooltip>
+        </div>
+      )}
+      <nav aria-label="Main navigation" className="flex w-full flex-col gap-1">
+        {navItems.map(({ href, icon: ItemIcon, id, isActive, label }) => {
+          return (
+            <SidebarTooltip key={id} content={label} isEnabled={hasTooltips}>
+              <Link
+                href={href}
+                onPress={onClose}
+                className={getNavLinkClassName(isActive)}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                <ItemIcon size={18} className="shrink-0" />
+                {isExpanded && <span className="truncate">{label}</span>}
+              </Link>
+            </SidebarTooltip>
+          );
+        })}
+      </nav>
+      <div className="border-border flex w-full flex-col gap-1 border-t pt-3">
+        {EXTERNAL_LINKS.map(({ href, icon: ItemIcon, id, label }) => {
+          return (
+            <SidebarTooltip key={id} content={label} isEnabled={hasTooltips}>
+              <Link
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(getNavLinkClassName(false), 'text-muted')}
+              >
+                <ItemIcon size={18} className="shrink-0" />
+                {isExpanded && (
+                  <>
+                    <span className="truncate">{label}</span>
+                    <ArrowSquareOutIcon className="text-muted/50 ms-auto size-4 shrink-0" />
+                  </>
+                )}
+              </Link>
+            </SidebarTooltip>
+          );
+        })}
+      </div>
+      <div
+        className={cn(
+          'border-border mt-auto flex w-full flex-col gap-2 border-t pt-3',
+          !isExpanded && 'items-center'
+        )}
+      >
+        {!isOverlay && (
+          <div
+            className={cn(
+              'flex items-center',
+              isExpanded ? 'justify-between' : 'flex-col justify-center gap-1'
+            )}
+          >
+            {isExpanded ? <ThemeToggle /> : <ThemeMenu />}
+            <SidebarModeSelect />
+          </div>
+        )}
+        {user ? (
+          <UserMenu isExpanded={isExpanded} />
+        ) : isExpanded ? (
+          <div className="flex w-full gap-2 lg:flex-col">
+            <CustomButton
+              size="sm"
+              href="/login"
+              onPress={onClose}
+              variant="bordered"
+              data-testid="login-button"
+            >
+              Log In
+              <CustomKbd size="sm" variant="default">
+                I
+              </CustomKbd>
+            </CustomButton>
+            <CustomButton
+              size="sm"
+              href="/register"
+              variant="primary"
+              onPress={onClose}
+              data-testid="register-button"
+            >
+              Join
+              <CustomKbd size="sm" variant="default">
+                J
+              </CustomKbd>
+            </CustomButton>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-2">
+            <SidebarTooltip content="Log In (I)" isEnabled={hasTooltips}>
+              <CustomButton
+                size="sm"
+                isIconOnly
+                href="/login"
+                variant="bordered"
+                aria-label="Log In"
+              >
+                <SignInIcon size={16} />
+              </CustomButton>
+            </SidebarTooltip>
+            <SidebarTooltip content="Join (J)" isEnabled={hasTooltips}>
+              <CustomButton
+                size="sm"
+                isIconOnly
+                href="/register"
+                variant="primary"
+                aria-label="Join"
+              >
+                <UserPlusIcon size={16} />
+              </CustomButton>
+            </SidebarTooltip>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SidebarContent;

--- a/src/components/sidebar/SidebarModeSelect.tsx
+++ b/src/components/sidebar/SidebarModeSelect.tsx
@@ -1,0 +1,62 @@
+import { Label, Dropdown } from '@heroui/react';
+import type { Icon } from '@phosphor-icons/react';
+import {
+  CheckIcon,
+  CursorIcon,
+  SidebarIcon,
+  ArrowsInLineHorizontalIcon,
+  ArrowsOutLineHorizontalIcon,
+} from '@phosphor-icons/react';
+
+import { CustomButton } from '@components';
+import { useSidebarMode, type SidebarMode } from '@hooks';
+
+const MODE_OPTIONS: { icon: Icon; id: SidebarMode; label: string }[] = [
+  { icon: ArrowsOutLineHorizontalIcon, id: 'expanded', label: 'Expanded' },
+  { icon: ArrowsInLineHorizontalIcon, id: 'collapsed', label: 'Collapsed' },
+  { icon: CursorIcon, id: 'hover', label: 'Expand on hover' },
+];
+
+const SidebarModeSelect = () => {
+  const { setSidebarMode, sidebarMode } = useSidebarMode();
+
+  return (
+    <Dropdown>
+      <CustomButton
+        size="sm"
+        isIconOnly
+        variant="ghost"
+        aria-label="Sidebar display options"
+      >
+        <SidebarIcon size={16} />
+      </CustomButton>
+      <Dropdown.Popover className="min-w-[210px]">
+        <Dropdown.Menu aria-label="Sidebar display">
+          {MODE_OPTIONS.map(({ icon: ModeIcon, id, label }) => {
+            return (
+              <Dropdown.Item
+                id={id}
+                key={id}
+                textValue={label}
+                className="justify-between"
+                onAction={() => {
+                  setSidebarMode(id);
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <ModeIcon className="size-4 shrink-0" />
+                  <Label>{label}</Label>
+                </div>
+                {sidebarMode === id && (
+                  <CheckIcon className="text-accent size-4 shrink-0" />
+                )}
+              </Dropdown.Item>
+            );
+          })}
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  );
+};
+
+export default SidebarModeSelect;

--- a/src/components/sidebar/ThemeMenu.tsx
+++ b/src/components/sidebar/ThemeMenu.tsx
@@ -1,0 +1,65 @@
+import { Label, Dropdown } from '@heroui/react';
+import {
+  MoonIcon,
+  CheckIcon,
+  SunDimIcon,
+  DesktopIcon,
+} from '@phosphor-icons/react';
+
+import { CustomButton } from '@components';
+import { ThemeModes } from '@const';
+import { useThemeMode } from '@hooks';
+
+const MODE_ICONS = {
+  [ThemeModes.DARK]: MoonIcon,
+  [ThemeModes.LIGHT]: SunDimIcon,
+  [ThemeModes.SYSTEM]: DesktopIcon,
+};
+
+const MODE_LABELS = {
+  [ThemeModes.DARK]: 'Dark',
+  [ThemeModes.LIGHT]: 'Light',
+  [ThemeModes.SYSTEM]: 'System',
+};
+
+const ThemeMenu = () => {
+  const { setThemeMode, themeMode } = useThemeMode();
+  const CurrentIcon = MODE_ICONS[themeMode];
+
+  return (
+    <Dropdown>
+      <CustomButton size="sm" isIconOnly variant="ghost" aria-label="Theme">
+        <CurrentIcon size={16} />
+      </CustomButton>
+      <Dropdown.Popover className="min-w-[150px]">
+        <Dropdown.Menu aria-label="Theme">
+          {Object.values(ThemeModes).map((mode) => {
+            const ModeIcon = MODE_ICONS[mode];
+
+            return (
+              <Dropdown.Item
+                id={mode}
+                key={mode}
+                className="justify-between"
+                textValue={MODE_LABELS[mode]}
+                onAction={() => {
+                  setThemeMode(mode);
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <ModeIcon className="size-4 shrink-0" />
+                  <Label>{MODE_LABELS[mode]}</Label>
+                </div>
+                {themeMode === mode && (
+                  <CheckIcon className="text-accent size-4 shrink-0" />
+                )}
+              </Dropdown.Item>
+            );
+          })}
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  );
+};
+
+export default ThemeMenu;

--- a/src/components/sidebar/UserMenu.tsx
+++ b/src/components/sidebar/UserMenu.tsx
@@ -1,0 +1,78 @@
+import { Label, Dropdown } from '@heroui/react';
+import { GearIcon, UserIcon, SignOutIcon } from '@phosphor-icons/react';
+
+import { CustomButton } from '@components';
+import { signOut } from '@services';
+import { useUser, useProfile, useMobileSidebarActions } from '@stores';
+
+type UserMenuProps = {
+  isExpanded?: boolean;
+};
+
+const UserMenu = ({ isExpanded = false }: UserMenuProps) => {
+  const user = useUser();
+  const profile = useProfile();
+  const { closeMobileSidebar } = useMobileSidebarActions();
+
+  const email = profile?.email || user?.email || 'Anonymous account';
+
+  return (
+    <Dropdown>
+      {isExpanded ? (
+        <CustomButton
+          variant="ghost"
+          aria-label="Open account menu"
+          className="h-auto w-full justify-start px-2 py-1.5"
+        >
+          <UserIcon size={20} className="shrink-0" />
+          <div className="flex min-w-0 flex-col items-start">
+            {!!profile?.name && (
+              <span className="max-w-full truncate text-sm leading-tight font-semibold">
+                {profile.name}
+              </span>
+            )}
+            <span className="text-muted max-w-full truncate text-xs leading-tight font-normal">
+              {email}
+            </span>
+          </div>
+        </CustomButton>
+      ) : (
+        <CustomButton
+          size="sm"
+          isIconOnly
+          variant="ghost"
+          aria-label="Open account menu"
+        >
+          <UserIcon size={18} />
+        </CustomButton>
+      )}
+      <Dropdown.Popover className="min-w-[200px]">
+        <Dropdown.Menu aria-label="Account">
+          <Dropdown.Item
+            id="settings"
+            href="/settings"
+            textValue="Settings"
+            onAction={closeMobileSidebar}
+          >
+            <GearIcon className="size-4 shrink-0" />
+            <Label>Settings</Label>
+          </Dropdown.Item>
+          <Dropdown.Item
+            id="logout"
+            variant="danger"
+            textValue="Log Out"
+            onAction={() => {
+              signOut();
+              closeMobileSidebar();
+            }}
+          >
+            <SignOutIcon className="text-danger size-4 shrink-0" />
+            <Label>Log Out</Label>
+          </Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  );
+};
+
+export default UserMenu;

--- a/src/components/sidebar/index.ts
+++ b/src/components/sidebar/index.ts
@@ -1,0 +1,5 @@
+export { default as AppSidebar } from './Sidebar';
+export { default as SidebarContent } from './SidebarContent';
+export { default as SidebarModeSelect } from './SidebarModeSelect';
+export { default as ThemeMenu } from './ThemeMenu';
+export { default as UserMenu } from './UserMenu';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,5 +7,9 @@ export { default as useKeyboardShortcut } from './use-keyboard-shortcut';
 export { default as useModifierKeys } from './use-modifier-keys';
 export { default as useScreenWidth } from './use-screen-width';
 export { default as useSession } from './use-session';
+export {
+  default as useSidebarMode,
+  type SidebarMode,
+} from './use-sidebar-mode';
 export { default as useTextField } from './use-text-field';
 export { default as useThemeMode } from './use-theme-mode';

--- a/src/hooks/use-sidebar-mode.ts
+++ b/src/hooks/use-sidebar-mode.ts
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export type SidebarMode = 'collapsed' | 'expanded' | 'hover';
+
+const STORAGE_KEY = 'sidebar-mode';
+
+const listeners = new Set<() => void>();
+
+const isSidebarMode = (value: string | null): value is SidebarMode => {
+  return value === 'collapsed' || value === 'expanded' || value === 'hover';
+};
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  window.addEventListener('storage', listener);
+
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener('storage', listener);
+  };
+};
+
+const getSnapshot = (): SidebarMode => {
+  const storedMode = localStorage.getItem(STORAGE_KEY);
+
+  return isSidebarMode(storedMode) ? storedMode : 'expanded';
+};
+
+const setSidebarMode = (mode: SidebarMode) => {
+  localStorage.setItem(STORAGE_KEY, mode);
+  listeners.forEach((listener) => {
+    return listener();
+  });
+};
+
+const useSidebarMode = () => {
+  const sidebarMode = React.useSyncExternalStore(subscribe, getSnapshot);
+
+  return { setSidebarMode, sidebarMode };
+};
+
+export default useSidebarMode;

--- a/src/pages/OAuthConsentPage.tsx
+++ b/src/pages/OAuthConsentPage.tsx
@@ -56,7 +56,7 @@ const OAuthConsentPage = () => {
         const returnTo = encodeURIComponent(
           window.location.pathname + window.location.search
         );
-        window.location.href = `/account?returnTo=${returnTo}`;
+        window.location.href = `/settings?returnTo=${returnTo}`;
 
         return;
       }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -27,7 +27,7 @@ import {
 } from '@stores';
 import { getErrorMessage } from '@utils';
 
-const AccountPage = () => {
+const SettingsPage = () => {
   useAuthSearchParams();
 
   const navigate = useNavigate();
@@ -49,7 +49,7 @@ const AccountPage = () => {
     setDefaultCurrency(profile?.defaultCurrency || 'EUR');
   }, [profile, handleEmailChange, handleNameChange]);
 
-  const title = <title>My Account | Habitrack</title>;
+  const title = <title>Settings | Habitrack</title>;
 
   const containerClassName = 'w-3xl mt-8 mx-auto flex flex-col';
 
@@ -178,10 +178,10 @@ const AccountPage = () => {
     <div className="flex h-lvh w-full flex-col items-start self-start px-8 py-2 lg:px-16 lg:py-4">
       {title}
       <div
-        data-testid="account-page"
+        data-testid="settings-page"
         className={cn(containerClassName, 'justify-self-start')}
       >
-        <h1 className="text-xl font-semibold">Your Account Settings</h1>
+        <h1 className="text-xl font-semibold">Settings</h1>
         {!!user?.isAnonymous && (
           <Alert status="warning" className="mt-4 w-full md:w-96">
             <Alert.Indicator />
@@ -347,6 +347,7 @@ const AccountPage = () => {
                 variant="secondary"
                 isDisabled={isUpdating}
                 testId="password-input"
+                autoComplete="new-password"
                 onChange={handlePasswordChange}
                 placeholder="Enter new password"
               />
@@ -388,4 +389,4 @@ const AccountPage = () => {
   );
 };
 
-export default AccountPage;
+export default SettingsPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,4 +1,3 @@
-export { default as AccountPage } from './AccountPage';
 export { default as AnonymousLoginPage } from './AnonymousLoginPage';
 export { default as DayCalendarPage } from './DayCalendarPage';
 export { default as ErrorFallbackPage } from './ErrorFallbackPage';
@@ -10,4 +9,5 @@ export { default as NotesPage } from './NotesPage';
 export { default as OAuthConsentPage } from './OAuthConsentPage';
 export { default as RegisterPage } from './RegisterPage';
 export { default as ResetPasswordPage } from './ResetPasswordPage';
+export { default as SettingsPage } from './SettingsPage';
 export { default as WeekCalendarPage } from './WeekCalendarPage';

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -14,7 +14,7 @@ export const signUp = async (
     email,
     password,
     options: {
-      emailRedirectTo: `${window.location.origin}/account?emailConfirmed=true`,
+      emailRedirectTo: `${window.location.origin}/settings?emailConfirmed=true`,
       data: decamelizeKeys({
         firstDayOfWeek,
       }),
@@ -67,7 +67,7 @@ export const linkGoogleIdentity = async () => {
   const { error } = await supabaseClient.auth.linkIdentity({
     provider: 'google',
     options: {
-      redirectTo: `${window.location.origin}/account`,
+      redirectTo: `${window.location.origin}/settings`,
     },
   });
 
@@ -88,7 +88,7 @@ export const convertAnonymousUser = async (email: string, password: string) => {
   const { error } = await supabaseClient.auth.updateUser(
     { email, password },
     {
-      emailRedirectTo: `${window.location.origin}/account?emailConfirmed=true`,
+      emailRedirectTo: `${window.location.origin}/settings?emailConfirmed=true`,
     }
   );
 
@@ -136,7 +136,7 @@ export const deleteUser = async () => {
 
 export const updateUser = async (attributes: UserAttributes) => {
   const { data, error } = await supabaseClient.auth.updateUser(attributes, {
-    emailRedirectTo: `${window.location.origin}/account?emailChangeConfirmed=true&newEmail=${attributes.email}&userId=${attributes}`,
+    emailRedirectTo: `${window.location.origin}/settings?emailChangeConfirmed=true&newEmail=${attributes.email}&userId=${attributes}`,
   });
 
   if (error) {
@@ -165,7 +165,7 @@ export const getUser = async () => {
 
 export const sendPasswordResetEmail = async (email: string) => {
   const { error } = await supabaseClient.auth.resetPasswordForEmail(email, {
-    redirectTo: `${window.location.origin}/account?passwordReset=true`,
+    redirectTo: `${window.location.origin}/settings?passwordReset=true`,
   });
 
   if (error) {

--- a/src/stores/ui.store.ts
+++ b/src/stores/ui.store.ts
@@ -42,12 +42,17 @@ export type UiSlice = {
   calendarFilters: CalendarFilters;
   calendarRange: [CalendarDateTime, CalendarDateTime];
   confirmation: ConfirmationState;
+  isMobileSidebarOpen: boolean;
   changeCalendarFilters: (filters: CalendarFilters) => void;
   changeCalendarRange: (range: [CalendarDateTime, CalendarDateTime]) => void;
   confirmationActions: {
     approveConfirmation: () => void;
     askConfirmation: (options?: ConfirmationOptions) => Promise<boolean>;
     rejectConfirmation: () => void;
+  };
+  mobileSidebarActions: {
+    closeMobileSidebar: () => void;
+    openMobileSidebar: () => void;
   };
   noteDrawer: {
     isOpen: boolean;
@@ -95,6 +100,7 @@ const initialConfirmationState = {
 export const createUiSlice: SliceCreator<keyof UiSlice> = (set) => {
   return {
     confirmation: initialConfirmationState,
+    isMobileSidebarOpen: false,
     changeCalendarFilters: (filters) => {
       set(
         (state) => {
@@ -167,6 +173,26 @@ export const createUiSlice: SliceCreator<keyof UiSlice> = (set) => {
           },
           undefined,
           'uiActions.rejectConfirmation'
+        );
+      },
+    },
+    mobileSidebarActions: {
+      closeMobileSidebar: () => {
+        set(
+          (state) => {
+            state.isMobileSidebarOpen = false;
+          },
+          undefined,
+          'uiActions.closeMobileSidebar'
+        );
+      },
+      openMobileSidebar: () => {
+        set(
+          (state) => {
+            state.isMobileSidebarOpen = true;
+          },
+          undefined,
+          'uiActions.openMobileSidebar'
         );
       },
     },
@@ -309,6 +335,18 @@ export const useNoteDrawerState = () => {
 export const useNoteDrawerActions = () => {
   return useBoundStore((state) => {
     return state.noteDrawerActions;
+  });
+};
+
+export const useMobileSidebarState = () => {
+  return useBoundStore((state) => {
+    return state.isMobileSidebarOpen;
+  });
+};
+
+export const useMobileSidebarActions = () => {
+  return useBoundStore((state) => {
+    return state.mobileSidebarActions;
   });
 };
 


### PR DESCRIPTION
## Description

Introduces a new desktop/mobile sidebar system with navigation, account controls, theme switching, and sidebar display modes. Refactors the header to mobile-focused controls and moves shortcut-driven note/log actions into the sidebar flow. Renames Account to Settings across routes/pages/redirects (with /account compatibility redirect) and updates auth-related redirect URLs plus UI state for mobile sidebar open/close.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Build process or tooling change
- [ ] Code style or formatting change
- [ ] Other (please describe)

[//]: # 'Uncomment the following lines if your change is related to an issue'
[//]: # '## Related Issues (if any)'
[//]: #
[//]: # 'Fixes #(issue number)'

## Checklist

- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [ ] I've updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive sidebar with desktop, mobile drawer, and hover or collapsed display modes.
  * Added sidebar navigation, theme selection, account menu, and quick actions for notes and logs.
  * Added a dedicated Settings page and updated account navigation to redirect there.
  * Preserved query parameters and URL fragments during account redirects and authentication flows.
  * Added mobile sidebar controls and keyboard shortcuts for common actions.
* **Bug Fixes**
  * Improved password-field autofill behavior on the Settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->